### PR TITLE
black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.8.0
+    hooks:
+    - id: black
+      language_version: python3.10.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
Adjusts all python code to fit PEP8 python code style when `git commit` is run.

- The devs might have to do `pre-commit install` ( or `pip install pre-commit` first, if that fails) in order for this to work. 
- TODO make git hooks install automatically when the project is installed.