### PR TITLE
Run all rules on data files

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import click
 import pytest
 
-from cin_validator.rule_engine import registry
+from cin_validator.rule_engine import registry, RuleContext
+from cin_validator.ingress import XMLtoCSV
+from cin_validator.utils import DataContainerWrapper
+
+import xml.etree.ElementTree as ET
 
 
 @click.group()
@@ -23,7 +27,28 @@ def list_cmd(ruleset):
     """List all rules in a ruleset"""
     importlib.import_module(f"cin_validator.{ruleset}")
     for rule in registry:
-        click.echo(f"{rule.code}\t{rule.description} ({rule.rule_type.name})")
+        click.echo(f"{rule.code}\t{rule.message} ({rule.rule_type.name})")
+
+@cli.command()
+@click.argument("filename", type=click.File("rt"), required=True)
+@click.option(
+    "--ruleset",
+    "-r",
+    default="rules.cin2022_23",
+    help="Which ruleset to use, e.g. rules.cin2022_23",
+)
+def run_all(filename:str, ruleset):
+    # TODO detect filetype xml/csv/zip. check if the directory is a folder.
+    fulltree = ET.parse(filename)
+    root = fulltree.getroot()
+    data_files = DataContainerWrapper(XMLtoCSV(root))
+    
+    importlib.import_module(f"cin_validator.{ruleset}")
+    for rule in registry:
+        
+        ctx = RuleContext(rule)
+        rule.func(data_files, ctx)
+        print(rule.code, len(list(ctx.issues)))
 
 
 @cli.command(name="test")

--- a/cin_validator/ingress.py
+++ b/cin_validator/ingress.py
@@ -8,7 +8,7 @@ import pandas as pd
 import xml.etree.ElementTree as ET
 
 # TODO make this work with from cin_validator.utils import get_values
-from utils import get_values, make_census_period
+from .utils import get_values, make_census_period
 
 # initialize all data sets as empty dataframes with columns names
 # whenever a child is created, it should add a row to each table where it exists.

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -18,3 +18,9 @@ def make_census_period(collection_year):
 
     return collection_start, collection_end
 
+class DataContainerWrapper:
+    def __init__(self, value) -> None:
+        self.value = value
+
+    def __getitem__(self, name):
+        return getattr(self.value, name.name)


### PR DESCRIPTION
This adds a command that runs all the coded rules on a CIN XML file.
`python -m cin_validator run-all .\fake_data\fake_CIN_data.xml` where `.\fake_data\fake_CIN_data.xml` is the file directory.