### PR TITLE
use ReferenceDate in make_census_period

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8545Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8545Q.py
@@ -15,7 +15,7 @@ from cin_validator.utils import make_census_period
 ChildIdentifiers = CINTable.ChildIdentifiers
 Header = CINTable.Header
 PersonDeathDate = ChildIdentifiers.PersonDeathDate
-Year = Header.Year
+ReferenceDate = Header.ReferenceDate
 
 # define characteristics of rule
 @rule_definition(
@@ -31,17 +31,17 @@ def validate(
     df = data_container[ChildIdentifiers]
     df_ref = data_container[Header]
 
-    """
-    If present, <PersonDeathDate> (N00108) must be within [Period_of_Census]
-    """
+    # If present, <PersonDeathDate> (N00108) must be within [Period_of_Census]
 
     df = df[[PersonDeathDate]]
 
     # Death date must not be null, invalid text dates are made null in the line above
     df = df[df[PersonDeathDate].notna()]
 
-    collection_year = df_ref[Year]
-    collection_start, collection_end = make_census_period(collection_year)
+    # Select out only the ReferenceDate column from the DataFrame
+    ref_date_series = df_ref[ReferenceDate]
+    collection_start, collection_end = make_census_period(ref_date_series)
+
     # DeathDate isn't in the financial year
     df = df[
         ~(
@@ -76,7 +76,7 @@ def test_validate():
     )
 
     fake_ident = pd.DataFrame({PersonDeathDate: p_death})
-    fake_head = pd.DataFrame({Year: ["2022"]})
+    fake_head = pd.DataFrame({ReferenceDate: ["31/03/2022"]})
 
     result = run_rule(validate, {ChildIdentifiers: fake_ident, Header: fake_head})
 

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -10,14 +10,25 @@ def get_values(xml_elements, table_dict, xml_block):
     return table_dict
 
 
-def make_census_period(collection_year):
-    if isinstance(collection_year, pd.Series):
-        # collection_year is a pandas series. Get it's value as a string by indexing the series' values array.
-        collection_year = collection_year.values[0]
-    previous_year = int(collection_year) - 1
-    collection_start = pd.to_datetime(f"01/04/{previous_year}", format="%d/%m/%Y")
+def make_census_period(reference_date):
+    """Generates the census period.
+    input [pd.Series]: ReferenceDate
+        column selected from Header DataFrame.
+    output [Tuple]: collection_start, collection_end
+        datetime objects where collection end equals reference date
+        and collection start is April 1st of the previous year"""
 
-    collection_end = pd.to_datetime(f"31/03/{collection_year}", format="%d/%m/%Y")
+    # reference_date is a pandas series. Get it's value as a string by indexing the series' values array.
+    reference_date = reference_date.values[0]
+
+    # the ReferenceDate value is always the collection_end date
+    collection_end = pd.to_datetime(reference_date, format="%d/%m/%Y")
+    # the collection start is the 1st of April of the previous year.
+    collection_start = (
+        pd.to_datetime(reference_date, format="%d/%m/%Y")
+        - pd.DateOffset(years=1)
+        + pd.DateOffset(days=1)
+    )
 
     return collection_start, collection_end
 


### PR DESCRIPTION
A lot of the rules use the word `ReferenceDate` and not just `period of census`.
Although the `Year` can be used to generate the period of census, it makes more sense to use the column name that is more frequently associated with it.