### PR TITLE
Rule structure: Multiple columns across multiple tables.

### DIFF
--- a/cin_validator/rule_engine/__context.py
+++ b/cin_validator/rule_engine/__context.py
@@ -46,6 +46,7 @@ class RuleContext:
     def __init__(self, definition: RuleDefinition):
         self.__definition = definition
         self.__issues = []
+        self.__type2_issues = []
 
     @property
     def definition(self):
@@ -58,6 +59,10 @@ class RuleContext:
         """Many columns, One Table, no merge involved"""
         self.__type1_issues = Type1(table, columns, row_df)
 
+    def push_type_2(self, table, columns, row_df):
+        table_tuple = Type1(table, columns, row_df)
+        self.__type2_issues.append(table_tuple)
+
     @property
     def issues(self):
         for issues in self.__issues:
@@ -66,3 +71,7 @@ class RuleContext:
     @property
     def type1_issues(self):
         return self.__type1_issues
+
+    @property
+    def type2_issues(self):
+        return self.__type2_issues

--- a/tests/rule_engine/test_linking.py
+++ b/tests/rule_engine/test_linking.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock
+
+import pandas as pd
+
+from cin_validator.rule_engine import IssueLocator, RuleContext
+
+
+def test_issues():
+    rule_context = RuleContext(Mock())
+    rule_context.push_issue("table_name", "column_name", [4, 7, 8])
+
+    assert list(rule_context.issues) == [
+        IssueLocator("table_name", "column_name", 4),
+        IssueLocator("table_name", "column_name", 7),
+        IssueLocator("table_name", "column_name", 8),
+    ]
+
+
+def test_type1():
+    """rules that involve columns in the same table which were not joined by merge."""
+    rule_context = RuleContext(Mock())
+    df_issues = pd.DataFrame(
+        [
+            {"ERROR_ID": (2, 8, 5), "ROW_ID": [23, 24]},
+            {"ERROR_ID": (3, 7, 2), "ROW_ID": [9]},
+        ]
+    )
+    rule_context.push_type_1("table_name", ["column1", "column2"], df_issues)
+
+    issues = rule_context.type1_issues
+    assert issues.table == "table_name"
+    assert issues.columns == ["column1", "column2"]
+    assert issues.row_df.equals(df_issues)
+
+
+def test_type2():
+    """
+    Stores linked error locations for rules that involve mutiple columns in multiple tables
+    """
+    rule_context = RuleContext(Mock())
+    df_issues_1 = pd.DataFrame(
+        [
+            {"ERROR_ID": (2, 8, 5), "ROW_ID": [23, 24]},
+            {"ERROR_ID": (3, 7, 2), "ROW_ID": [18]},
+        ]
+    )
+    df_issues_2 = pd.DataFrame(
+        [
+            {"ERROR_ID": (3, 7, 2), "ROW_ID": [9]},
+        ]
+    )
+    df_issues_3 = pd.DataFrame(
+        [
+            {"ERROR_ID": (2, 8, 5), "ROW_ID": [0, 1]},
+            {"ERROR_ID": (3, 7, 2), "ROW_ID": [9]},
+        ]
+    )
+    rule_context.push_type_2("table_one", ["column1", "column2"], df_issues_1)
+    rule_context.push_type_2("table_two", ["column3"], df_issues_2)
+    rule_context.push_type_2("table_three", ["column4", "column5"], df_issues_3)
+
+    issues_list = rule_context.type2_issues
+    assert isinstance(issues_list, list)
+    assert len(issues_list) == 3
+    # choose a table and check it's content
+    issues = issues_list[2]
+    assert issues.table == "table_three"
+    assert issues.columns == ["column4", "column5"]
+    assert issues.row_df.equals(df_issues_3)


### PR DESCRIPTION
The changes in this pull request add the push_type2 method to the RuleContext class; enabling type 2 rules to be implemented.