### PR TITLE
Rule 8896: example of type3

### DIFF
--- a/Documentation/rule_logic_demos/type3_rule8896.ipynb
+++ b/Documentation/rule_logic_demos/type3_rule8896.ipynb
@@ -1,0 +1,447 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cfd77f1c",
+   "metadata": {},
+   "source": [
+    "# Code logic of Rule 8896\n",
+    "\n",
+    "We wouldn't want you to simply fill in the gaps and replace variable names when you do these rules. It is important to us that you learn the concepts behind the rules too, as you go. \n",
+    "\n",
+    "This file demonstrates the code logic of Rule 8896, a type 3 rule. Type 3 rules are those that define scenarios that should not occur within a group. So these values might be correct on their own but if something else happens in the group, then that same value could flag the error. \n",
+    "\n",
+    "In this case, the rule says that \"Within one CINdetails group, there must not be more than one Assessments group that has no AssessmentAuthorisationDate (N00160) recorded\". \n",
+    "\n",
+    "So if an AssessmentAuthorisationDate is missing (equal to pd.NA), this rule won't flag it just because of that. What this rule will do is check if there is another AssessmentAuthorisationDate that is missing in the group. If there is, then all the positions where AssessmentAuthorisationDate is missing will be flagged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "057af961",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b3cc253",
+   "metadata": {},
+   "source": [
+    "The CIN validator tool contains a number of background checks and guidelines on how things should be done. As helpful as this is, it might not allow you to experiment much or run your code on the fly. So sometimes I get the data out into a clean file and write my python logic against it.\n",
+    "\n",
+    "Create some data and take note of the positions that you expect to be flagged.\n",
+    "\n",
+    "You would notice that you now need to put the column names in strings as standard Python practice requires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "6561070c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  LAchildID CINdetailsID AssessmentAuthorisationDate\n",
+      "0    child1       cinID1                         NaT\n",
+      "1    child1       cinID1                         NaT\n",
+      "2    child1       cinID2                         NaT\n",
+      "3    child2       cinID1                  2021-05-26\n",
+      "4    child2       cinID2                         NaT\n",
+      "5    child2       cinID2                         NaT\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_assessments = pd.DataFrame(\n",
+    "    [   #child1\n",
+    "        {   # fail\n",
+    "            \"LAchildID\": \"child1\",\n",
+    "            \"CINdetailsID\": \"cinID1\",\n",
+    "            \"AssessmentAuthorisationDate\": pd.NA, # 0 first nan date in group\n",
+    "        },\n",
+    "        {   # fail\n",
+    "            \"LAchildID\": \"child1\",\n",
+    "            \"CINdetailsID\": \"cinID1\",\n",
+    "            \"AssessmentAuthorisationDate\": pd.NA, # 1 second nan date in group\n",
+    "        },\n",
+    "        {   # won't be flagged because there is not more than one nan authorisation date in this group.\n",
+    "            \"LAchildID\": \"child1\",\n",
+    "            \"CINdetailsID\": \"cinID2\",\n",
+    "            \"AssessmentAuthorisationDate\": pd.NA, # 2\n",
+    "        }, \n",
+    "        # child2 \n",
+    "        {\n",
+    "            \"LAchildID\": \"child2\",\n",
+    "            \"CINdetailsID\": \"cinID1\", \n",
+    "            \"AssessmentAuthorisationDate\": \"26/05/2021\", # 3 ignored. not nan\n",
+    "        },\n",
+    "        {   # fail\n",
+    "            \"LAchildID\": \"child2\",\n",
+    "            \"CINdetailsID\": \"cinID2\",\n",
+    "            \"AssessmentAuthorisationDate\": pd.NA, # 4 first nan date in group\n",
+    "        },  \n",
+    "        {   # fail\n",
+    "            \"LAchildID\": \"child2\",\n",
+    "            \"CINdetailsID\": \"cinID2\",\n",
+    "            \"AssessmentAuthorisationDate\": pd.NA, # 5 second nan date in group\n",
+    "        },\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# if rule requires columns containing date values, convert those columns to datetime objects first. Do it here in the test_validate function, not above.\n",
+    "sample_assessments[\"AssessmentAuthorisationDate\"] = pd.to_datetime(\n",
+    "    sample_assessments[\"AssessmentAuthorisationDate\"], format=\"%d/%m/%Y\", errors=\"coerce\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# See what your data looks like\n",
+    "print(sample_assessments)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3daa82c6",
+   "metadata": {},
+   "source": [
+    "When you start, it is wise to ask yourself the question \"How do I get all the conditions that fail into one place?\".\n",
+    "In this case, our first step is to get together all the conditions that could fail. That is, the locations where AssessmentAuthorisationDate is missing. Later on, we can proceed to check how many exist per group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5d680fb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ROW_ID LAchildID CINdetailsID AssessmentAuthorisationDate\n",
+      "0       0    child1       cinID1                         NaT\n",
+      "1       1    child1       cinID1                         NaT\n",
+      "2       2    child1       cinID2                         NaT\n",
+      "4       4    child2       cinID2                         NaT\n",
+      "5       5    child2       cinID2                         NaT\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = sample_assessments\n",
+    "df.index.name = \"ROW_ID\"\n",
+    "df.reset_index(inplace=True)\n",
+    "df2 = df[df[\"AssessmentAuthorisationDate\"].isna()]\n",
+    "\n",
+    "# See what the data looks like now\n",
+    "print(df2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e3e3ba",
+   "metadata": {},
+   "source": [
+    "Generally, we would groupby the columns that define our group and count the number of items in each column. However, the count method ignores NaNs and in this case that it what we want to count. So since we have filtered only the NaN values, we can replace then with a value that can be counted. I chose to use the integer 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "04972883",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df2.loc[:,\"AssessmentAuthorisationDate\"].fillna(1, inplace=True)\n",
+    "\n",
+    "# This line was added to take care of a warning being raised here. You can ignore it in other rules.\n",
+    "pd.options.mode.chained_assignment = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d71f216",
+   "metadata": {},
+   "source": [
+    "Now we can count.\n",
+    "We need to groupby LAchildID and CINdetailsID because eventhough we are concerned with CINdetails groups, CINdetails groups are subgroups of each child. For example, two unique children can each contain a CINdetails group whose ID is \"abc\" within them. If we do not group by child first, our code will interpret the groups from these separate children as if they were the same because LAchildID has not been included to distinguish them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a3986340",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LAchildID  CINdetailsID\n",
+      "child1     cinID1          2\n",
+      "           cinID2          1\n",
+      "child2     cinID2          2\n",
+      "Name: AssessmentAuthorisationDate, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# count how many occurences of missing \"AssessmentAuthorisationDate\" per CINdetails group in each child.\n",
+    "group_result = df2.groupby([\"LAchildID\", \"CINdetailsID\"])[\"AssessmentAuthorisationDate\"].count()\n",
+    "\n",
+    "print(group_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f1f6e93",
+   "metadata": {},
+   "source": [
+    "The line below does the same thing as the line above. However, it shows you why we need to reset_index after doing the groupby. This is because the columns that we groupedby become the index and we have to push them back into column form. Also, you would notice that our count result is now assigned to the column we put in the square bracket of the groupby statement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1392c96f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  LAchildID CINdetailsID  AssessmentAuthorisationDate\n",
+      "0    child1       cinID1                            2\n",
+      "1    child1       cinID2                            1\n",
+      "2    child2       cinID2                            2\n"
+     ]
+    }
+   ],
+   "source": [
+    "df2 = df2.groupby([\"LAchildID\", \"CINdetailsID\"])[\"AssessmentAuthorisationDate\"].count().reset_index()\n",
+    "\n",
+    "# See what the data looks like now\n",
+    "print(df2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e562da78",
+   "metadata": {},
+   "source": [
+    "We get the count result by selecting the column we put in the square bracket of the groupby statement. The failing positions are only those in which there was more than one occurence of AssessmentAuthorisationDate as a missing value within the group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a21d629d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  LAchildID CINdetailsID  AssessmentAuthorisationDate\n",
+      "0    child1       cinID1                            2\n",
+      "2    child2       cinID2                            2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# filter out the instances where \"AssessmentAuthorisationDate\" is missing more than once in a CINdetails group.\n",
+    "df2 = df2[df2[\"AssessmentAuthorisationDate\"]>1]\n",
+    "\n",
+    "# See what the data looks like now\n",
+    "print(df2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf25d6c4",
+   "metadata": {},
+   "source": [
+    "In type3 rules, a group is our unit of testing. So the column relationship that defines the group also defines the error IDs. That is, in the end the locations that fail per group should be linked to each other."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f6da226",
+   "metadata": {},
+   "source": [
+    "We start by generating the IDs of all the failing positions which we have identified. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f3e848a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ROW_ID LAchildID CINdetailsID AssessmentAuthorisationDate          ERROR_ID\n",
+      "0       0    child1       cinID1                         NaT  (child1, cinID1)\n",
+      "1       1    child1       cinID1                         NaT  (child1, cinID1)\n",
+      "2       2    child1       cinID2                         NaT  (child1, cinID2)\n",
+      "3       3    child2       cinID1                  2021-05-26  (child2, cinID1)\n",
+      "4       4    child2       cinID2                         NaT  (child2, cinID2)\n",
+      "5       5    child2       cinID2                         NaT  (child2, cinID2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "issue_ids = tuple(\n",
+    "    zip(df2[\"LAchildID\"], df2[\"CINdetailsID\"],)\n",
+    ")\n",
+    "df[\"ERROR_ID\"] = tuple(\n",
+    "    zip(df[\"LAchildID\"], df[\"CINdetailsID\"],)\n",
+    ")\n",
+    "\n",
+    "# See what the data looks like now, including ERROR_ID that has been created.\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cb6efda",
+   "metadata": {},
+   "source": [
+    "Then we go to the initial dataset, generate an ID column using that same column combination and select the rows where the ID values appear among the IDs of the failing locations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "9282e369",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ROW_ID LAchildID CINdetailsID AssessmentAuthorisationDate          ERROR_ID\n",
+      "0       0    child1       cinID1                         NaT  (child1, cinID1)\n",
+      "1       1    child1       cinID1                         NaT  (child1, cinID1)\n",
+      "4       4    child2       cinID2                         NaT  (child2, cinID2)\n",
+      "5       5    child2       cinID2                         NaT  (child2, cinID2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_issues = df[df.ERROR_ID.isin(issue_ids)]\n",
+    "\n",
+    "# See what the data looks like now\n",
+    "print(df_issues)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76b6eeeb",
+   "metadata": {},
+   "source": [
+    "In real life, this df_issues will contain all the other columns that came with the table. That data is heavy to move around so we only select the columns which we need."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0017d193",
+   "metadata": {},
+   "source": [
+    "We would like to know all the rows that failed because of the same reason. That is, lets group together all the ROW_IDs that have the same ERROR_ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "5614e6d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ERROR_ID\n",
+      "(child1, cinID1)    [0, 1]\n",
+      "(child2, cinID2)    [4, 5]\n",
+      "Name: ROW_ID, dtype: object\n"
+     ]
+    }
+   ],
+   "source": [
+    "group_result = df_issues.groupby(\"ERROR_ID\")[\"ROW_ID\"].apply(list)\n",
+    "\n",
+    "# See what the data looks like now\n",
+    "print(group_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e684709f",
+   "metadata": {},
+   "source": [
+    "The line below does the same thing as the code above, then it shows you why we need to reset_index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "a895898c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           ERROR_ID  ROW_ID\n",
+      "0  (child1, cinID1)  [0, 1]\n",
+      "1  (child2, cinID2)  [4, 5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_issues = df_issues.groupby(\"ERROR_ID\")[\"ROW_ID\"].apply(list).reset_index()\n",
+    "\n",
+    "# See what the data looks like now\n",
+    "print(df_issues)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a98ad88",
+   "metadata": {},
+   "source": [
+    "Now, we can push this to the issue location accumulator that prepares the data which will be sent to the frontend."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cin_validator/rules/cin2022_23/rule_8896.py
+++ b/cin_validator/rules/cin2022_23/rule_8896.py
@@ -1,0 +1,174 @@
+from typing import Mapping
+
+import pandas as pd
+
+from cin_validator.rule_engine import CINTable, RuleContext, rule_definition
+from cin_validator.rules.cin2022_23.rule_8925 import LAchildID
+from cin_validator.test_engine import run_rule
+
+# Get tables and columns of interest from the CINTable object defined in rule_engine/__api.py
+
+Assessments = CINTable.Assessments
+AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
+LAchildID = Assessments.LAchildID
+CINdetailsID = Assessments.CINdetailsID
+
+# define characteristics of rule
+@rule_definition(
+    # write the rule code here, in place of 8896
+    code=8896,
+    # replace Assessments with the value in the module column of the excel sheet corresponding to this rule .
+    module=CINTable.Assessments,
+    # replace the message with the corresponding value for this rule, gotten from the excel sheet.
+    message="Within one CINDetails group there are 2 or more open Assessments groups",
+    # The column names tend to be the words within the < > signs in the github issue description.
+    affected_fields=[AssessmentAuthorisationDate],
+)
+def validate(
+    data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
+):
+    # PREPARING DATA
+
+    # Replace Assessments with the name of the table you need.
+    df = data_container[Assessments]
+    # Before you begin, rename the index and make it a column, so that the initial row positions can be kept intact.
+    df.index.name = "ROW_ID"
+    df.reset_index(inplace=True)
+
+    # lOGIC
+    # Implement rule logic as described by the Github issue.
+    # Put the description as a comment above the implementation as shown.
+
+    # Within one <CINdetails> group, there must not be more than one <Assessments> group that has no <AssessmentAuthorisationDate> (N00160) recorded
+
+    # DF_CHECK: APPLY GROUPBYs IN A SEPARATE DATAFRAME SO THAT OTHER COLUMNS ARE NOT LOST OR CORRUPTED. THEN, MAP THE RESULTS TO THE INITIAL DATAFRAME.
+    df_check = df.copy()
+    # get all the locations where AssessmentAuthorisationDate is null
+    df_check = df_check[df_check[AssessmentAuthorisationDate].isna()]
+    # We'll have to count the number of nan values per group. NaNs cannot be counted so replace them with something that can.
+    # Do this only if your rule requires that you interact with a column made up of all NaNs.
+    df_check[AssessmentAuthorisationDate].fillna(1, inplace=True)
+    # count how many occurences of missing AssessmentAuthorisationDate per CINdetails group in each child.
+    df_check = (
+        df_check.groupby([LAchildID, CINdetailsID])[AssessmentAuthorisationDate]
+        .count()
+        .reset_index()
+    )
+    #
+    # when you groupby as shown above a series is returned where the columns in the round brackets become the index and the groupby result are the values.
+    # resetting the index pushes the columns in the () back as columns of the dataframe and assigns the groupby result to the column in the square bracket.
+    #
+    # filter out the instances where AssessmentAuthorisationDate is missing more than once in a CINdetails group.
+    df_check = df_check[df_check[AssessmentAuthorisationDate] > 1]
+    issue_ids = tuple(zip(df_check[LAchildID], df_check[CINdetailsID]))
+
+    # DF_ISSUES: GET ALL THE DATA ABOUT THE LOCATIONS THAT WERE IDENTIFIED IN DF_CHECK
+    df["ERROR_ID"] = tuple(zip(df[LAchildID], df[CINdetailsID]))
+    df_issues = df[df.ERROR_ID.isin(issue_ids)]
+
+    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
+    rule_context.push_type_1(
+        table=Assessments, columns=[AssessmentAuthorisationDate], row_df=df_issues
+    )
+
+
+def test_validate():
+    # Create some sample data such that some values pass the validation and some fail.
+    sample_assessments = pd.DataFrame(
+        [  # child1
+            {  # fail
+                LAchildID: "child1",
+                CINdetailsID: "cinID1",
+                AssessmentAuthorisationDate: pd.NA,  # 0 first nan date in group
+            },
+            {  # fail
+                LAchildID: "child1",
+                CINdetailsID: "cinID1",
+                AssessmentAuthorisationDate: pd.NA,  # 1 second nan date in group
+            },
+            {  # won't be flagged because there is not more than one nan authorisation date in this group.
+                LAchildID: "child1",
+                CINdetailsID: "cinID2",
+                AssessmentAuthorisationDate: pd.NA,  # 2
+            },
+            # child2
+            {
+                LAchildID: "child2",
+                CINdetailsID: "cinID1",
+                AssessmentAuthorisationDate: "26/05/2021",  # 3 ignored. not nan
+            },
+            {  # fail
+                LAchildID: "child2",
+                CINdetailsID: "cinID2",
+                AssessmentAuthorisationDate: pd.NA,  # 4 first nan date in group
+            },
+            {  # fail
+                LAchildID: "child2",
+                CINdetailsID: "cinID2",
+                AssessmentAuthorisationDate: pd.NA,  # 5 second nan date in group
+            },
+        ]
+    )
+    # if rule requires columns containing date values, convert those columns to datetime objects first. Do it here in the test_validate function, not above.
+    sample_assessments[AssessmentAuthorisationDate] = pd.to_datetime(
+        sample_assessments[AssessmentAuthorisationDate],
+        format="%d/%m/%Y",
+        errors="coerce",
+    )
+
+    # Run rule function passing in our sample data
+    result = run_rule(validate, {Assessments: sample_assessments})
+
+    # Use .type1_issues to check for the result of .push_type1_issues() which you used above.
+    issues = result.type1_issues
+
+    # get table name and check it. Replace ChildProtectionPlans with the name of your table.
+    issue_table = issues.table
+    assert issue_table == Assessments
+
+    # check that the right columns were returned. Replace CPPstartDate and CPPendDate with a list of your columns.
+    issue_columns = issues.columns
+    assert issue_columns == [AssessmentAuthorisationDate]
+
+    # check that the location linking dataframe was formed properly.
+    issue_rows = issues.row_df
+    # replace 2 with the number of failing points you expect from the sample data.
+    assert len(issue_rows) == 2
+    # check that the failing locations are contained in a DataFrame having the appropriate columns. These lines do not change.
+    assert isinstance(issue_rows, pd.DataFrame)
+    assert issue_rows.columns.to_list() == ["ERROR_ID", "ROW_ID"]
+
+    # Create the dataframe which you expect, based on the fake data you created. It should have two columns.
+    # - The first column is ERROR_ID which contains the unique combination that identifies each error instance, which you decided on earlier.
+    # - The second column in ROW_ID which contains a list of index positions that belong to each error instance.
+
+    # The ROW ID values represent the index positions where you expect the sample data to fail the validation check.
+    expected_df = pd.DataFrame(
+        [
+            {
+                "ERROR_ID": (
+                    "child1",
+                    "cinID1",
+                ),
+                "ROW_ID": [0, 1],
+            },
+            {
+                "ERROR_ID": (
+                    "child2",
+                    "cinID2",
+                ),
+                "ROW_ID": [4, 5],
+            },
+        ]
+    )
+    assert issue_rows.equals(expected_df)
+
+    # Check that the rule definition is what you wrote in the context above.
+
+    # replace 8925 with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == 8896
+    assert (
+        result.definition.message
+        == "Within one CINDetails group there are 2 or more open Assessments groups"
+    )

--- a/cin_validator/rules/cin2022_23/rule_8896.py
+++ b/cin_validator/rules/cin2022_23/rule_8896.py
@@ -68,7 +68,7 @@ def validate(
 
     df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
-    rule_context.push_type_1(
+    rule_context.push_type_3(
         table=Assessments, columns=[AssessmentAuthorisationDate], row_df=df_issues
     )
 
@@ -120,8 +120,8 @@ def test_validate():
     # Run rule function passing in our sample data
     result = run_rule(validate, {Assessments: sample_assessments})
 
-    # Use .type1_issues to check for the result of .push_type1_issues() which you used above.
-    issues = result.type1_issues
+    # Use .type3_issues to check for the result of .push_type3_issues() which you used above.
+    issues = result.type3_issues
 
     # get table name and check it. Replace ChildProtectionPlans with the name of your table.
     issue_table = issues.table


### PR DESCRIPTION
Type3 rules tend to involve 1 column. They define things that should not happen in a group.
Examples of groups are CINdetails groups, CPP groups and so on.