### PR TITLE
Implement type3

### DIFF
--- a/cin_validator/rule_engine/__context.py
+++ b/cin_validator/rule_engine/__context.py
@@ -60,8 +60,13 @@ class RuleContext:
         self.__type1_issues = Type1(table, columns, row_df)
 
     def push_type_2(self, table, columns, row_df):
+        """Multiple columns, multiple tables"""
         table_tuple = Type1(table, columns, row_df)
         self.__type2_issues.append(table_tuple)
+
+    def push_type_3(self, table, columns, row_df):
+        """One Table, values are checked per group"""
+        self.__type3_issues = Type1(table, columns, row_df)
 
     @property
     def issues(self):
@@ -75,3 +80,7 @@ class RuleContext:
     @property
     def type2_issues(self):
         return self.__type2_issues
+
+    @property
+    def type3_issues(self):
+        return self.__type3_issues

--- a/tests/rule_engine/test_linking.py
+++ b/tests/rule_engine/test_linking.py
@@ -67,3 +67,23 @@ def test_type2():
     assert issues.table == "table_three"
     assert issues.columns == ["column4", "column5"]
     assert issues.row_df.equals(df_issues_3)
+
+
+def test_type3():
+    """Rules that check relationships within a group."""
+    rule_context = RuleContext(Mock())
+    df_issues = pd.DataFrame(
+        [
+            {"ERROR_ID": (2, 8, 5), "ROW_ID": [23, 24]},
+            {"ERROR_ID": (3, 7, 2), "ROW_ID": [9]},
+        ]
+    )
+    rule_context.push_type_3("table_name", ["column1"], df_issues)
+
+    issues = rule_context.type3_issues
+    assert issues.table == "table_name"
+    assert len(issues.columns) == 1
+    assert issues.columns == [
+        "column1",
+    ]
+    assert issues.row_df.equals(df_issues)


### PR DESCRIPTION
The changes in this pull request implement and test a push_type3 method for the RuleContext object.

The way type3 rules should be pushed seems very similar to the way type1 rules with 1 column are pushed. However, push_type3 has been implemented separately because it is possible that some rules will need a different push structure. In case they do, it is wise to have separated the mechanisms from each other from the start. 

This pull request ought to be merged before the Rule8896 branch can run.