### PR TITLE
Fixes print statements, adds date input flexibility for reference date

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -48,7 +48,7 @@ def run_all(filename: str, ruleset):
 
         ctx = RuleContext(rule)
         rule.func(data_files, ctx)
-        #  TODO determine what to use for the group_keys argument 
+        #  TODO determine what to use for the group_keys argument
         print(rule.code, len(list(ctx.issues)))
 
 

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -47,9 +47,14 @@ def run_all(filename: str, ruleset):
     for rule in registry:
 
         ctx = RuleContext(rule)
+
         rule.func(data_files, ctx)
         #  TODO determine what to use for the group_keys argument
-        print(rule.code, len(list(ctx.issues)))
+        if len(list(ctx.issues)) == 0:
+            print(rule.code, len(list(ctx.issues)))
+        else:
+            for i in range(len(list(ctx.issues))):
+                print(rule.code, list(ctx.issues)[i], rule.message)
 
 
 @cli.command(name="test")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -51,10 +51,10 @@ def run_all(filename: str, ruleset):
         rule.func(data_files, ctx)
         ruleID = rule.code
         ruleID = ErrorReport(
-            codes = rule.code,
-            number = len(list(ctx.issues)),
-            locations = list(ctx.issues),
-            message = rule.message,
+            codes=rule.code,
+            number=len(list(ctx.issues)),
+            locations=list(ctx.issues),
+            message=rule.message,
         )
         print(ruleID.codes)
         print(ruleID.number)

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -7,7 +7,7 @@ import pytest
 
 from cin_validator.ingress import XMLtoCSV
 from cin_validator.rule_engine import RuleContext, registry
-from cin_validator.utils import DataContainerWrapper
+from cin_validator.utils import DataContainerWrapper, ErrorReport
 
 
 @click.group()
@@ -49,12 +49,22 @@ def run_all(filename: str, ruleset):
         ctx = RuleContext(rule)
 
         rule.func(data_files, ctx)
-        #  TODO determine what to use for the group_keys argument
-        if len(list(ctx.issues)) == 0:
-            print(rule.code, len(list(ctx.issues)))
-        else:
-            for i in range(len(list(ctx.issues))):
-                print(rule.code, list(ctx.issues)[i], rule.message)
+        ruleID = rule.code
+        ruleID = ErrorReport(
+            codes = rule.code,
+            number = len(list(ctx.issues)),
+            locations = list(ctx.issues),
+            message = rule.message,
+        )
+        print(ruleID.codes)
+        print(ruleID.number)
+        print(ruleID.message)
+        print(ruleID.locations)
+        # if len(list(ctx.issues)) == 0:
+        #     print(rule.code, len(list(ctx.issues)))
+        # else:
+        #     for i in range(len(list(ctx.issues))):
+        #         print(rule.code, list(ctx.issues)[i], rule.message)
 
 
 @cli.command(name="test")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -48,6 +48,7 @@ def run_all(filename: str, ruleset):
 
         ctx = RuleContext(rule)
         rule.func(data_files, ctx)
+        #  TODO determine what to use for the group_keys argument 
         print(rule.code, len(list(ctx.issues)))
 
 

--- a/cin_validator/rules/cin2022_23/rule_4011.py
+++ b/cin_validator/rules/cin2022_23/rule_4011.py
@@ -49,7 +49,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
 
     rule_context.push_type_1(
         table=CINplanDates, columns=[CINPlanEndDate, CINPlanStartDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_4011.py
+++ b/cin_validator/rules/cin2022_23/rule_4011.py
@@ -49,7 +49,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
 
     rule_context.push_type_1(
         table=CINplanDates, columns=[CINPlanEndDate, CINPlanStartDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_4012Q.py
+++ b/cin_validator/rules/cin2022_23/rule_4012Q.py
@@ -38,7 +38,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=CINplanDates, columns=[CINPlanStartDate, CINPlanEndDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_4012Q.py
+++ b/cin_validator/rules/cin2022_23/rule_4012Q.py
@@ -38,7 +38,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=CINplanDates, columns=[CINPlanStartDate, CINPlanEndDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8535Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8535Q.py
@@ -58,7 +58,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildIdentifiers,

--- a/cin_validator/rules/cin2022_23/rule_8535Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8535Q.py
@@ -58,7 +58,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildIdentifiers,

--- a/cin_validator/rules/cin2022_23/rule_8608.py
+++ b/cin_validator/rules/cin2022_23/rule_8608.py
@@ -61,7 +61,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=Assessments,

--- a/cin_validator/rules/cin2022_23/rule_8608.py
+++ b/cin_validator/rules/cin2022_23/rule_8608.py
@@ -61,7 +61,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=Assessments,

--- a/cin_validator/rules/cin2022_23/rule_8614.py
+++ b/cin_validator/rules/cin2022_23/rule_8614.py
@@ -63,7 +63,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=Assessments,

--- a/cin_validator/rules/cin2022_23/rule_8614.py
+++ b/cin_validator/rules/cin2022_23/rule_8614.py
@@ -63,7 +63,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=Assessments,

--- a/cin_validator/rules/cin2022_23/rule_8615.py
+++ b/cin_validator/rules/cin2022_23/rule_8615.py
@@ -44,7 +44,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
 
     rule_context.push_type_1(
         table=Section47,

--- a/cin_validator/rules/cin2022_23/rule_8615.py
+++ b/cin_validator/rules/cin2022_23/rule_8615.py
@@ -44,7 +44,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
 
     rule_context.push_type_1(
         table=Section47,

--- a/cin_validator/rules/cin2022_23/rule_8630.py
+++ b/cin_validator/rules/cin2022_23/rule_8630.py
@@ -44,7 +44,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
 
     rule_context.push_type_1(
         table=CINdetails,

--- a/cin_validator/rules/cin2022_23/rule_8630.py
+++ b/cin_validator/rules/cin2022_23/rule_8630.py
@@ -44,7 +44,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
 
     rule_context.push_type_1(
         table=CINdetails,

--- a/cin_validator/rules/cin2022_23/rule_8805.py
+++ b/cin_validator/rules/cin2022_23/rule_8805.py
@@ -61,7 +61,7 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=CINDetails, columns=[CINclosureDate, ReasonForClosure], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8805.py
+++ b/cin_validator/rules/cin2022_23/rule_8805.py
@@ -61,7 +61,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=CINDetails, columns=[CINclosureDate, ReasonForClosure], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8840.py
+++ b/cin_validator/rules/cin2022_23/rule_8840.py
@@ -58,7 +58,7 @@ def validate(
         zip(df_issues[LAchildID], df_issues[CPPstartDate], df_issues[CPPendDate])
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildProtectionPlans, columns=[CPPstartDate, CPPendDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8840.py
+++ b/cin_validator/rules/cin2022_23/rule_8840.py
@@ -58,7 +58,11 @@ def validate(
         zip(df_issues[LAchildID], df_issues[CPPstartDate], df_issues[CPPendDate])
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildProtectionPlans, columns=[CPPstartDate, CPPendDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8870Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8870Q.py
@@ -36,17 +36,17 @@ def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
     df = data_container[Section47]
-    print(df)
+    
 
     # <InitialCPCtarget> (N00109) should not be a Saturday, Sunday
     # Convert column to date format
     df[InitialCPCtarget] = pd.to_datetime(
         df[InitialCPCtarget], format="%d-%m-%Y", errors="coerce"
     )
-    print(df)
+    
     # .weekday() returns the integer value for each day (0-6) with weekends being 5 and 6
     failing_indices = df[df[InitialCPCtarget].dt.weekday >= 5].index
-    print(failing_indices)
+    
     rule_context.push_issue(
         table=Section47, field=InitialCPCtarget, row=failing_indices
     )

--- a/cin_validator/rules/cin2022_23/rule_8870Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8870Q.py
@@ -36,17 +36,16 @@ def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
     df = data_container[Section47]
-    
 
     # <InitialCPCtarget> (N00109) should not be a Saturday, Sunday
     # Convert column to date format
     df[InitialCPCtarget] = pd.to_datetime(
         df[InitialCPCtarget], format="%d-%m-%Y", errors="coerce"
     )
-    
+
     # .weekday() returns the integer value for each day (0-6) with weekends being 5 and 6
     failing_indices = df[df[InitialCPCtarget].dt.weekday >= 5].index
-    
+
     rule_context.push_issue(
         table=Section47, field=InitialCPCtarget, row=failing_indices
     )

--- a/cin_validator/rules/cin2022_23/rule_8925.py
+++ b/cin_validator/rules/cin2022_23/rule_8925.py
@@ -56,7 +56,7 @@ def validate(
         zip(df_issues[LAchildID], df_issues[CPPstartDate], df_issues[CPPendDate])
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildProtectionPlans, columns=[CPPstartDate, CPPendDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8925.py
+++ b/cin_validator/rules/cin2022_23/rule_8925.py
@@ -56,7 +56,11 @@ def validate(
         zip(df_issues[LAchildID], df_issues[CPPstartDate], df_issues[CPPendDate])
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildProtectionPlans, columns=[CPPstartDate, CPPendDate], row_df=df_issues

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -10,6 +10,15 @@ def get_values(xml_elements, table_dict, xml_block):
     return table_dict
 
 
+def make_date(date):
+    try:
+        date = pd.to_datetime(date, format="%Y/%m/%d", errors="coerce")
+    except:
+        date = pd.to_datetime(date, format="%d/%m/%Y", errors="coerce")
+
+    return date
+
+
 def make_census_period(reference_date):
     """Generates the census period.
     input [pd.Series]: ReferenceDate
@@ -22,29 +31,14 @@ def make_census_period(reference_date):
     reference_date = reference_date.values[0]
 
     #  Try/except to allow for different datetime formats
-    # TODO can this be DRYed up?
-    try:
-        # the ReferenceDate value is always the collection_end date
-        collection_end = pd.to_datetime(reference_date, format="%d/%m/%Y")
 
-        # the collection start is the 1st of April of the previous year.
-        collection_start = (
-            pd.to_datetime(reference_date, format="%d/%m/%Y")
-            - pd.DateOffset(years=1)
-            + pd.DateOffset(days=1)
-        )
-    except:
-        # the ReferenceDate value is always the collection_end date
-        collection_end = pd.to_datetime(
-            reference_date, format="%Y/%m/%d", errors="coerce"
-        )
+    # the ReferenceDate value is always the collection_end date
+    collection_end = make_date(reference_date)
 
-        # the collection start is the 1st of April of the previous year.
-        collection_start = (
-            pd.to_datetime(reference_date, format="%Y/%m/%d", errors="coerce")
-            - pd.DateOffset(years=1)
-            + pd.DateOffset(days=1)
-        )
+    # the collection start is the 1st of April of the previous year.
+    collection_start = (
+        make_date(reference_date) - pd.DateOffset(years=1) + pd.DateOffset(days=1)
+    )
 
     return collection_start, collection_end
 

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -50,13 +50,13 @@ class DataContainerWrapper:
     def __getitem__(self, name):
         return getattr(self.value, name.name)
 
-class ErrorReport():
-    ''' Class containing rules, number of errors per rule, and locations 
-    per rule.'''
-    def __init__(self, codes: int, number: int, locations, message: str): 
+
+class ErrorReport:
+    """Class containing rules, number of errors per rule, and locations
+    per rule."""
+
+    def __init__(self, codes: int, number: int, locations, message: str):
         self.codes = codes
         self.number = number
         self.locations = locations
         self.message = message
-
-        

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -49,3 +49,14 @@ class DataContainerWrapper:
 
     def __getitem__(self, name):
         return getattr(self.value, name.name)
+
+class ErrorReport():
+    ''' Class containing rules, number of errors per rule, and locations 
+    per rule.'''
+    def __init__(self, codes: int, number: int, locations, message: str): 
+        self.codes = codes
+        self.number = number
+        self.locations = locations
+        self.message = message
+
+        

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -22,6 +22,7 @@ def make_census_period(reference_date):
     reference_date = reference_date.values[0]
 
     #  Try/except to allow for different datetime formats
+    # TODO can this be DRYed up?
     try:
         # the ReferenceDate value is always the collection_end date
         collection_end = pd.to_datetime(reference_date, format="%d/%m/%Y")

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -21,14 +21,29 @@ def make_census_period(reference_date):
     # reference_date is a pandas series. Get it's value as a string by indexing the series' values array.
     reference_date = reference_date.values[0]
 
-    # the ReferenceDate value is always the collection_end date
-    collection_end = pd.to_datetime(reference_date, format="%d/%m/%Y")
-    # the collection start is the 1st of April of the previous year.
-    collection_start = (
-        pd.to_datetime(reference_date, format="%d/%m/%Y")
-        - pd.DateOffset(years=1)
-        + pd.DateOffset(days=1)
-    )
+    #  Try/except to allow for different datetime formats
+    try:
+        # the ReferenceDate value is always the collection_end date
+        collection_end = pd.to_datetime(reference_date, format="%d/%m/%Y")
+
+        # the collection start is the 1st of April of the previous year.
+        collection_start = (
+            pd.to_datetime(reference_date, format="%d/%m/%Y")
+            - pd.DateOffset(years=1)
+            + pd.DateOffset(days=1)
+        )
+    except:
+        # the ReferenceDate value is always the collection_end date
+        collection_end = pd.to_datetime(
+            reference_date, format="%Y/%m/%d", errors="coerce"
+        )
+
+        # the collection start is the 1st of April of the previous year.
+        collection_start = (
+            pd.to_datetime(reference_date, format="%Y/%m/%d", errors="coerce")
+            - pd.DateOffset(years=1)
+            + pd.DateOffset(days=1)
+        )
 
     return collection_start, collection_end
 


### PR DESCRIPTION
Some rules had print statement sin which printed to the console when running through the CLI

Reference dates could be formatted in one of two ways, this allows both within the make_census_period function. It's done inside that function for now as it doesn't seem like it's needed anywhere else, and it means we wouldn't have to change how any rules are coded. Potential future work to DRY it up?