### PR TITLE
fixed make_date fucntion to allow varied inputs

### DIFF
--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -10,12 +10,12 @@ def get_values(xml_elements, table_dict, xml_block):
     return table_dict
 
 
-def make_date(date):
-    try:
-        date = pd.to_datetime(date, format="%Y/%m/%d", errors="coerce")
-    except:
-        date = pd.to_datetime(date, format="%d/%m/%Y", errors="coerce")
-
+def make_date(date_input):
+    '''Allows Ymd or dmY date inputs, used for make_cancus_period.
+    Important for test_validate functions'''
+    date = pd.to_datetime(date_input, format="%Y/%m/%d", errors="coerce")
+    if pd.isna(date):
+        date = pd.to_datetime(date_input, format="%d/%m/%Y", errors="coerce")
     return date
 
 


### PR DESCRIPTION
fixes bug that didn't allow for varied date inputs in reference dates, the original try/except didn't consider the try to fail if it produced NaTs