### PR TITLE
Fix group keys

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -56,10 +56,10 @@ def run_all(filename: str, ruleset):
             locations=list(ctx.issues),
             message=rule.message,
         )
-        print(ruleID.codes)
-        print(ruleID.number)
-        print(ruleID.message)
-        print(ruleID.locations)
+        # print(ruleID.codes)
+        # print(ruleID.number)
+        # print(ruleID.message)
+        # print(ruleID.locations)
         # if len(list(ctx.issues)) == 0:
         #     print(rule.code, len(list(ctx.issues)))
         # else:

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -45,15 +45,17 @@ def run_all(filename: str, ruleset):
 
     importlib.import_module(f"cin_validator.{ruleset}")
     for rule in registry:
-
-        ctx = RuleContext(rule)
-        print(rule.code)
-        rule.func(data_files, ctx)
-        if len(list(ctx.issues)) == 0:
-            print(rule.code, len(list(ctx.issues)))
-        else:
-            for i in range(len(list(ctx.issues))):
-                print(rule.code, list(ctx.issues)[i], rule.message)
+        try:
+            ctx = RuleContext(rule)
+            rule.func(data_files, ctx)
+            if len(list(ctx.issues)) == 0:
+                print(rule.code, len(list(ctx.issues)))
+            else:
+                pass
+                for i in range(len(list(ctx.issues))):
+                    print(rule.code, list(ctx.issues)[i], rule.message)
+        except:
+            print("Error with rule " + str(rule.code))
 
 
 @cli.command(name="test")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -7,7 +7,7 @@ import pytest
 
 from cin_validator.ingress import XMLtoCSV
 from cin_validator.rule_engine import RuleContext, registry
-from cin_validator.utils import DataContainerWrapper, ErrorReport
+from cin_validator.utils import DataContainerWrapper
 
 
 @click.group()
@@ -47,24 +47,13 @@ def run_all(filename: str, ruleset):
     for rule in registry:
 
         ctx = RuleContext(rule)
-
+        print(rule.code)
         rule.func(data_files, ctx)
-        ruleID = rule.code
-        ruleID = ErrorReport(
-            codes=rule.code,
-            number=len(list(ctx.issues)),
-            locations=list(ctx.issues),
-            message=rule.message,
-        )
-        # print(ruleID.codes)
-        # print(ruleID.number)
-        # print(ruleID.message)
-        # print(ruleID.locations)
-        # if len(list(ctx.issues)) == 0:
-        #     print(rule.code, len(list(ctx.issues)))
-        # else:
-        #     for i in range(len(list(ctx.issues))):
-        #         print(rule.code, list(ctx.issues)[i], rule.message)
+        if len(list(ctx.issues)) == 0:
+            print(rule.code, len(list(ctx.issues)))
+        else:
+            for i in range(len(list(ctx.issues))):
+                print(rule.code, list(ctx.issues)[i], rule.message)
 
 
 @cli.command(name="test")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -45,6 +45,7 @@ def run_all(filename: str, ruleset):
 
     importlib.import_module(f"cin_validator.{ruleset}")
     for rule in registry:
+
         try:
             ctx = RuleContext(rule)
             rule.func(data_files, ctx)
@@ -55,6 +56,8 @@ def run_all(filename: str, ruleset):
                 for i in range(len(list(ctx.issues))):
                     print(rule.code, list(ctx.issues)[i], rule.message)
         except:
+            ctx = RuleContext(rule)
+            #rule.func(data_files, ctx)
             print("Error with rule " + str(rule.code))
 
 

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -57,7 +57,7 @@ def run_all(filename: str, ruleset):
                     print(rule.code, list(ctx.issues)[i], rule.message)
         except:
             ctx = RuleContext(rule)
-            #rule.func(data_files, ctx)
+            # rule.func(data_files, ctx)
             print("Error with rule " + str(rule.code))
 
 

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -56,8 +56,6 @@ def run_all(filename: str, ruleset):
                 for i in range(len(list(ctx.issues))):
                     print(rule.code, list(ctx.issues)[i], rule.message)
         except:
-            ctx = RuleContext(rule)
-            # rule.func(data_files, ctx)
             print("Error with rule " + str(rule.code))
 
 

--- a/cin_validator/rules/cin2022_23/rule_1105.py
+++ b/cin_validator/rules/cin2022_23/rule_1105.py
@@ -70,7 +70,7 @@ def validate(
 
     df_CPP_issues = (
         df_CPP.merge(df, left_on="ROW_ID", right_on="ROW_ID_CPP")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )
@@ -78,7 +78,7 @@ def validate(
 
     df_CIN_issues = (
         df_CIN.merge(df, left_on="ROW_ID", right_on="ROW_ID_CIN")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )

--- a/cin_validator/rules/cin2022_23/rule_1105.py
+++ b/cin_validator/rules/cin2022_23/rule_1105.py
@@ -74,7 +74,6 @@ def validate(
         .apply(list)
         .reset_index()
     )
-    print(df_CPP_issues)
 
     df_CIN_issues = (
         df_CIN.merge(df, left_on="ROW_ID", right_on="ROW_ID_CIN")

--- a/cin_validator/rules/cin2022_23/rule_8525.py
+++ b/cin_validator/rules/cin2022_23/rule_8525.py
@@ -45,8 +45,7 @@ def validate(
     condition_2 = df[PersonBirthDate].notna() & df[ExpectedPersonBirthDate].notna()
 
     # get all the data that fits the failing condition. Reset the index so that ROW_ID now becomes a column of df
-    df_issues = df[condition_1 | condition_2].reset_index()
-
+    df_issues = df[condition_1 | condition_2].copy().reset_index()
     # (LAchildID,PersonBirthDate,ExpectedPersonBirthDate) could have been used. However, in some failing conditions,
     # both (PersonBirthDate,ExpectedPersonBirthDate) can be null so their combination does not serve as a unique ID.
     # Since this is the ChildIdentifiers table and LAchildID is typically unique in it. We use that to serve as a last resort ID.
@@ -57,7 +56,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=ChildIdentifiers,

--- a/cin_validator/rules/cin2022_23/rule_8525.py
+++ b/cin_validator/rules/cin2022_23/rule_8525.py
@@ -42,11 +42,11 @@ def validate(
     # Either Date of Birth or Expected Date of Birth must be provided (but not both)
     # condition_1 = (df[PersonBirthDate].isna() & df[ExpectedPersonBirthDate].isna())
     condition_1 = (df[PersonBirthDate].isna()) & (df[ExpectedPersonBirthDate].isna())
-    condition_2 = (df[PersonBirthDate].notna()) & (df[ExpectedPersonBirthDate].notna())
+    condition_2 = df[PersonBirthDate].notna() & df[ExpectedPersonBirthDate].notna()
 
     # get all the data that fits the failing condition. Reset the index so that ROW_ID now becomes a column of df
-    # df_issues = df[condition_1 | condition_2].copy().reset_index()
-    df_issues = df[condition_1] | df[condition_2]
+    df_issues = df[condition_1 | condition_2].reset_index()
+
 
     # (LAchildID,PersonBirthDate,ExpectedPersonBirthDate) could have been used. However, in some failing conditions,
     # both (PersonBirthDate,ExpectedPersonBirthDate) can be null so their combination does not serve as a unique ID.

--- a/cin_validator/rules/cin2022_23/rule_8525.py
+++ b/cin_validator/rules/cin2022_23/rule_8525.py
@@ -33,6 +33,7 @@ def validate(
     # Replace ChildIdentifiers with the name of the table you need.
     df = data_container[ChildIdentifiers]
     # Before you begin, rename the index so that the initial row positions can be kept intact.
+    df = df.drop(columns=['ROW_ID'], errors='ignore')
     df.index.name = "ROW_ID"
 
     # lOGIC

--- a/cin_validator/rules/cin2022_23/rule_8525.py
+++ b/cin_validator/rules/cin2022_23/rule_8525.py
@@ -42,10 +42,12 @@ def validate(
     # Either Date of Birth or Expected Date of Birth must be provided (but not both)
     # condition_1 = (df[PersonBirthDate].isna() & df[ExpectedPersonBirthDate].isna())
     condition_1 = (df[PersonBirthDate].isna()) & (df[ExpectedPersonBirthDate].isna())
-    condition_2 = df[PersonBirthDate].notna() & df[ExpectedPersonBirthDate].notna()
+    condition_2 = (df[PersonBirthDate].notna()) & (df[ExpectedPersonBirthDate].notna())
 
     # get all the data that fits the failing condition. Reset the index so that ROW_ID now becomes a column of df
-    df_issues = df[condition_1 | condition_2].copy().reset_index()
+    # df_issues = df[condition_1 | condition_2].copy().reset_index()
+    df_issues = df[condition_1] | df[condition_2]
+
     # (LAchildID,PersonBirthDate,ExpectedPersonBirthDate) could have been used. However, in some failing conditions,
     # both (PersonBirthDate,ExpectedPersonBirthDate) can be null so their combination does not serve as a unique ID.
     # Since this is the ChildIdentifiers table and LAchildID is typically unique in it. We use that to serve as a last resort ID.

--- a/cin_validator/rules/cin2022_23/rule_8525.py
+++ b/cin_validator/rules/cin2022_23/rule_8525.py
@@ -41,12 +41,16 @@ def validate(
 
     # Either Date of Birth or Expected Date of Birth must be provided (but not both)
     # condition_1 = (df[PersonBirthDate].isna() & df[ExpectedPersonBirthDate].isna())
-    condition_1 = (df[PersonBirthDate].isna()) & (df[ExpectedPersonBirthDate].isna())
-    condition_2 = df[PersonBirthDate].notna() & df[ExpectedPersonBirthDate].notna()
+
+    # condition_1 = (df[PersonBirthDate].isna()) & (df[ExpectedPersonBirthDate].isna())
+    # condition_2 = df[PersonBirthDate].notna() & df[ExpectedPersonBirthDate].notna()
+
+    mega_condition = (
+        df[PersonBirthDate].isna() & df[ExpectedPersonBirthDate].notna()
+    ) | (df[PersonBirthDate].notna() & df[ExpectedPersonBirthDate].isna())
 
     # get all the data that fits the failing condition. Reset the index so that ROW_ID now becomes a column of df
-    df_issues = df[condition_1 | condition_2].reset_index()
-
+    df_issues = df[~mega_condition].reset_index()
 
     # (LAchildID,PersonBirthDate,ExpectedPersonBirthDate) could have been used. However, in some failing conditions,
     # both (PersonBirthDate,ExpectedPersonBirthDate) can be null so their combination does not serve as a unique ID.

--- a/cin_validator/rules/cin2022_23/rule_8525.py
+++ b/cin_validator/rules/cin2022_23/rule_8525.py
@@ -33,7 +33,7 @@ def validate(
     # Replace ChildIdentifiers with the name of the table you need.
     df = data_container[ChildIdentifiers]
     # Before you begin, rename the index so that the initial row positions can be kept intact.
-    df = df.drop(columns=['ROW_ID'], errors='ignore')
+    df = df.drop(columns=["ROW_ID"], errors="ignore")
     df.index.name = "ROW_ID"
 
     # lOGIC

--- a/cin_validator/rules/cin2022_23/rule_8736.py
+++ b/cin_validator/rules/cin2022_23/rule_8736.py
@@ -69,7 +69,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=Assessments,

--- a/cin_validator/rules/cin2022_23/rule_8736.py
+++ b/cin_validator/rules/cin2022_23/rule_8736.py
@@ -80,7 +80,6 @@ def validate(
         columns=[AssessmentAuthorisationDate, AssessmentActualStartDate],
         row_df=df_issues,
     )
-    print(df_issues)
 
 
 def test_validate():

--- a/cin_validator/rules/cin2022_23/rule_8810.py
+++ b/cin_validator/rules/cin2022_23/rule_8810.py
@@ -49,7 +49,11 @@ def validate(
         zip(df_issues[LAchildID], df_issues[ReasonForClosure], df_issues[CINdetailsID])
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=CINdetails, columns=[ReasonForClosure, CINclosureDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8841.py
+++ b/cin_validator/rules/cin2022_23/rule_8841.py
@@ -87,13 +87,13 @@ def validate(
     # we can now map the suffixes columns to their corresponding source tables such that the failing ROW_IDs and ERROR_IDs exist per table.
     df_cpp_issues = (
         df_cpp.merge(df_merged, left_on="ROW_ID", right_on="ROW_ID_cpp")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )
     df_reviews_issues = (
         df_reviews.merge(df_merged, left_on="ROW_ID", right_on="ROW_ID_reviews")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )

--- a/cin_validator/rules/cin2022_23/rule_8896.py
+++ b/cin_validator/rules/cin2022_23/rule_8896.py
@@ -66,7 +66,11 @@ def validate(
     df["ERROR_ID"] = tuple(zip(df[LAchildID], df[CINdetailsID]))
     df_issues = df[df.ERROR_ID.isin(issue_ids)]
 
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_3(
         table=Assessments, columns=[AssessmentAuthorisationDate], row_df=df_issues

--- a/cin_validator/rules/cin2022_23/rule_8897.py
+++ b/cin_validator/rules/cin2022_23/rule_8897.py
@@ -122,7 +122,11 @@ def validate(
         )
     )
     df_issues["ERROR_ID"] = link_id
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_1(
         table=Assessments,

--- a/cin_validator/rules/cin2022_23/rule_8915.py
+++ b/cin_validator/rules/cin2022_23/rule_8915.py
@@ -73,7 +73,6 @@ def validate(
         .apply(list)
         .reset_index()
     )
-    print(df_CPP_issues)
 
     df_CI_issues = (
         df_CI.merge(df, left_on="ROW_ID", right_on="ROW_ID_CI")

--- a/cin_validator/rules/cin2022_23/rule_8915.py
+++ b/cin_validator/rules/cin2022_23/rule_8915.py
@@ -69,7 +69,7 @@ def validate(
 
     df_CPP_issues = (
         df_CPP.merge(df, left_on="ROW_ID", right_on="ROW_ID_CPP")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )
@@ -77,7 +77,7 @@ def validate(
 
     df_CI_issues = (
         df_CI.merge(df, left_on="ROW_ID", right_on="ROW_ID_CI")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )

--- a/cin_validator/rules/cin2022_23/rule_8935.py
+++ b/cin_validator/rules/cin2022_23/rule_8935.py
@@ -62,7 +62,11 @@ def validate(
     df["ERROR_ID"] = tuple(zip(df[LAchildID], df[CPPID]))
     df_issues = df[df.ERROR_ID.isin(issue_ids)]
 
-    df_issues = df_issues.groupby("ERROR_ID")["ROW_ID"].apply(list).reset_index()
+    df_issues = (
+        df_issues.groupby("ERROR_ID", group_keys=False)["ROW_ID"]
+        .apply(list)
+        .reset_index()
+    )
     # Ensure that you do not change the ROW_ID, and ERROR_ID column names which are shown above. They are keywords in this project.
     rule_context.push_type_3(
         table=ChildProtectionPlans, columns=[CPPendDate], row_df=df_issues

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -49,14 +49,3 @@ class DataContainerWrapper:
 
     def __getitem__(self, name):
         return getattr(self.value, name.name)
-
-
-class ErrorReport:
-    """Class containing rules, number of errors per rule, and locations
-    per rule."""
-
-    def __init__(self, codes: int, number: int, locations, message: str):
-        self.codes = codes
-        self.number = number
-        self.locations = locations
-        self.message = message


### PR DESCRIPTION
Fixes group_key warnings in some rules which raised them by setting group_keys=False in them all

Contains a temporary fix for the error in 8525 where df=data_cintainer[...] produced a dataframe which already had ROW_ID by dropping it, and setting errors='ignore' for when it's fixed. The cause of this needs to be identified and fixed.

Added a temporary try/except to run-all which lets you run through every rule, see error numbers and locations, and get messages for every rule which cause errors. This should probably be a different CLI command to run-all to aid with debugging.