### PR TITLE
Resolve erratic behaviour in run-all command

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -43,7 +43,7 @@ def run_all(filename: str, ruleset, errorselect):
     # TODO detect filetype xml/csv/zip. check if the directory is a folder.
     fulltree = ET.parse(filename)
     root = fulltree.getroot()
-    data_files = DataContainerWrapper(XMLtoCSV(root))
+    data_files_obj = DataContainerWrapper(XMLtoCSV(root))
 
     importlib.import_module(f"cin_validator.{ruleset}")
 
@@ -51,7 +51,7 @@ def run_all(filename: str, ruleset, errorselect):
     all_rules_issue_locs = pd.DataFrame()
     rules_passed = []
     for rule in registry:
-
+        data_files = data_files_obj.__deepcopy__({})
         try:
             ctx = RuleContext(rule)
             rule.func(data_files, ctx)
@@ -92,10 +92,10 @@ def run_all(filename: str, ruleset, errorselect):
         except:
             print("Error with rule " + str(rule.code))
 
-    json_issue_report = all_rules_issue_locs.to_dict(orient="records")
+    #json_issue_report = all_rules_issue_locs.to_dict(orient="records")
+    
     print(issue_instances)
     print(all_rules_issue_locs)
-    print(json_issue_report)
 
     # Allows selection of error by ERROR_ID,
     # converts errorselect argument to tuple to do the slice.

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -89,11 +89,11 @@ def run_all(filename: str, ruleset, errorselect):
                     ignore_index=True,
                 )
 
-        except:
-            print("Error with rule " + str(rule.code))
+        except Exception as e:
+            print(f"Error with rule {rule.code}: {type(e).__name__}, {e}")
 
-    #json_issue_report = all_rules_issue_locs.to_dict(orient="records")
-    
+    # json_issue_report = all_rules_issue_locs.to_dict(orient="records")
+
     print(issue_instances)
     print(all_rules_issue_locs)
 

--- a/cin_validator/rules/cin2022_23/rule_4008.py
+++ b/cin_validator/rules/cin2022_23/rule_4008.py
@@ -85,13 +85,13 @@ def validate(
     # we can now map the suffixes columns to their corresponding source tables such that the failing ROW_IDs and ERROR_IDs exist per table.
     df_cpp_issues = (
         df_ci.merge(df_merged, left_on="ROW_ID", right_on="ROW_ID_ci")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )
     df_reviews_issues = (
         df_cpd.merge(df_merged, left_on="ROW_ID", right_on="ROW_ID_cpd")
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )

--- a/cin_validator/rules/cin2022_23/rule_4015.py
+++ b/cin_validator/rules/cin2022_23/rule_4015.py
@@ -64,7 +64,7 @@ def validate(
         df_cinplan.merge(
             df_merged, how="inner", left_on="ROW_ID", right_on="ROW_ID_plan"
         )
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )
@@ -73,7 +73,7 @@ def validate(
         df_cindetail.merge(
             df_merged, how="inner", left_on="ROW_ID", right_on="ROW_ID_det"
         )
-        .groupby("ERROR_ID")["ROW_ID"]
+        .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
         .apply(list)
         .reset_index()
     )

--- a/cin_validator/rules/cin2022_23/rule_8555.py
+++ b/cin_validator/rules/cin2022_23/rule_8555.py
@@ -78,7 +78,6 @@ def validate(
             df_merged[LAchildID], df_merged[CINreferralDate], df_merged[PersonDeathDate]
         )
     )
-    print(df_merged)
     df_CINDetails_issues = (
         df_CINDetails.merge(df_merged, left_on="ROW_ID", right_on="ROW_ID_CINDetails")
         .groupby("ERROR_ID")["ROW_ID"]

--- a/cin_validator/rules/cin2022_23/rule_8585Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8585Q.py
@@ -73,7 +73,6 @@ def validate(
         .apply(list)
         .reset_index()
     )
-    print(df_CI_issues)
 
     df_CIN_issues = (
         df_CIN.merge(df, left_on="ROW_ID", right_on="ROW_ID_CIN")
@@ -176,7 +175,6 @@ def test_validate():
             },
         ]
     )
-    print(expected_df)
     assert issue_rows.equals(expected_df)
 
     assert result.definition.code == "8585Q"

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from copy import deepcopy
+
+import pandas as pd
+
 
 def get_values(xml_elements, table_dict, xml_block):
     for element in xml_elements:
@@ -80,7 +82,7 @@ class DataContainerWrapper:
 
     def __copy__(self):
         cls = self.__class__
-        result =cls.__new__(cls)
+        result = cls.__new__(cls)
         result.__dict__.update(self.__dict__)
         return result
 

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-
+from copy import deepcopy
 
 def get_values(xml_elements, table_dict, xml_block):
     for element in xml_elements:
@@ -77,3 +77,18 @@ class DataContainerWrapper:
 
     def __getitem__(self, name):
         return getattr(self.value, name.name)
+
+    def __copy__(self):
+        cls = self.__class__
+        result =cls.__new__(cls)
+        result.__dict__.update(self.__dict__)
+        return result
+
+    def __deepcopy__(self, memo):
+        # the memo param is a dictionary that defines the parts of the class the should be shared between copies.
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            setattr(result, k, deepcopy(v, memo))
+        return result


### PR DESCRIPTION
The changes in this pull request
- Ensures that each rule runs on a copy of the data to prevent the original data from being changed within the rules.

Source:
It was noticed that the tools produced significantly different results when run locally and when run on codespaces. This turned out to be because of two main reasons,
- some rules were editing the data files (they aren't supposed to)
- the rules were not being run in the same order (local env is windows and codespaces env is linux)

Solution:
- Make a copy of the data each time a rule is run.