### PR TITLE
Implement return level validation

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -62,6 +62,7 @@ def run_all(filename: str, ruleset, issue_id, output):
 
     # print(issue_instances)
     # print(all_rules_issue_locs)
+    # print(validator.rule_descriptors)
 
 
 @cli.command(name="test")

--- a/cin_validator/rule_engine/__context.py
+++ b/cin_validator/rule_engine/__context.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import List
 
 import pandas as pd
@@ -57,6 +56,10 @@ class RuleContext:
         table_tuple = Type1(table, columns, row_df)
         self.__type3_issues.append(table_tuple)
 
+    def push_la_level(self, rule_code, rule_description):
+        """Rules that check relationships across the whole local authority"""
+        self.__la_issues = (rule_code, rule_description)
+
     # PROPERTIES FOR TEST_VALIDATE FUNCTIONS
     @property
     def issues(self):
@@ -75,6 +78,10 @@ class RuleContext:
     @property
     def type3_issues(self):
         return self.__type3_issues
+
+    @property
+    def la_issues(self):
+        return self.__la_issues
 
     # PROPERTIES FOR CREATING THE ERROR REPORT
     @property

--- a/cin_validator/rule_engine/__context.py
+++ b/cin_validator/rule_engine/__context.py
@@ -164,3 +164,15 @@ class RuleContext:
         except:
             # all non-type3 rules return this.
             return []
+
+    @property
+    def la_level_issues(self):
+        """Creates DataFrame of return level validation errors"""
+        try:
+            code, desc = self.__la_issues
+            la_df = pd.DataFrame(
+                [{"rule_code": code, "rule_description": desc, "la_level": True}]
+            )
+            return la_df
+        except:
+            return []

--- a/tests/rule_engine/test_context.py
+++ b/tests/rule_engine/test_context.py
@@ -246,3 +246,18 @@ def test_type_three():
             ]
         )
     ).all()
+
+
+def test_la_level():
+    """Rules that check relationships across the whole local authority"""
+    rule_context = RuleContext(Mock())
+    rule_context.code = "2000"
+    rule_context.description = "return-level validation rule"
+    check = pd.DataFrame([1])
+    if len(check):
+        rule_context.push_la_level(rule_context.code, rule_context.description)
+    else:
+        pass
+
+    issues = rule_context.la_issues
+    assert issues == ("2000", "return-level validation rule")

--- a/tests/rule_engine/test_context.py
+++ b/tests/rule_engine/test_context.py
@@ -248,7 +248,7 @@ def test_type_three():
     ).all()
 
 
-def test_la_level():
+def test_la_issues():
     """Rules that check relationships across the whole local authority"""
     rule_context = RuleContext(Mock())
     rule_context.code = "2000"
@@ -261,3 +261,27 @@ def test_la_level():
 
     issues = rule_context.la_issues
     assert issues == ("2000", "return-level validation rule")
+
+
+def test_la_level():
+    """DataFrame for rules that check relationships across the whole local authority"""
+    rule_context = RuleContext(Mock())
+    rule_context.code = "2000"
+    rule_context.description = "return-level validation rule"
+    check = pd.DataFrame([1])
+    if len(check):
+        rule_context.push_la_level(rule_context.code, rule_context.description)
+    else:
+        pass
+
+    issues = rule_context.la_level_issues
+    expected = pd.DataFrame(
+        [
+            {
+                "rule_code": "2000",
+                "rule_description": "return-level validation rule",
+                "la_level": True,
+            }
+        ]
+    )
+    assert issues.equals(expected)


### PR DESCRIPTION
This has all we need for now. 

However, NaNs are produced in the rule_descriptors object when the child-level and la-level rules are combined. That should be looked into.