### PR TITLE
Include child ID in issue report

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -50,8 +50,8 @@ def run_all(filename: str, ruleset, issue_id, output):
     all_rules_issue_locs = validator.all_rules_issue_locs
 
     if output:
-        error_report = validator.json_issue_report
-        rule_defs = validator.json_rule_descriptors
+        error_report = validator.all_rules_issue_locs.to_json(orient="records")
+        rule_defs = validator.rule_descriptors.to_json(orient="records")
 
         # generating sample files for the frontend.
         # TODO. when frontend dev is complete, change this to generate csv.

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -50,7 +50,8 @@ def run_all(filename: str, ruleset, issue_id, output):
     all_rules_issue_locs = validator.all_rules_issue_locs
 
     if output:
-        error_report = validator.all_rules_issue_locs.to_json(orient="records")
+        # TODO when dict of dfs can be passed into this class, run include_issue_child on issue_report
+        issue_report = validator.all_rules_issue_locs.to_json(orient="records")
         rule_defs = validator.rule_descriptors.to_json(orient="records")
 
         # generating sample files for the frontend.
@@ -61,7 +62,7 @@ def run_all(filename: str, ruleset, issue_id, output):
             json.dump(rule_defs, f)
 
         with open("issue_report.json", "w") as f:
-            json.dump(error_report, f)
+            json.dump(issue_report, f)
 
     # print(issue_instances)
     # print(all_rules_issue_locs)

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -144,3 +144,43 @@ class CinValidationSession:
             ]
         else:
             pass
+
+
+def include_issue_child(issue_df, cin_data):
+    """
+    :param DataFrame issue_df: complete data about all issue locations.
+    :param dict cin_data: dictionary of dataframes generated when cin xml is converted to tabular format.
+    """
+
+    la_level_issues = issue_df[issue_df["tables_affected"].isna()]
+    header_issues = issue_df[issue_df["tables_affected"] == "Header"]
+    tables_with_childid = [la_level_issues, header_issues]
+    for table in issue_df["tables_affected"].dropna().unique():
+        if table == "Header":
+            # the header table doesn't contain child id. It is like metadata
+            continue
+        table_df = issue_df[issue_df["tables_affected"] == table]
+
+        # get index values of the rows that fail.
+        table_rows = table_df["ROW_ID"].unique()
+
+        # naming the index of the data allows it to be mapped back to the issue_df
+        table_data = cin_data[table]
+        table_data.index.name = "ROW_ID"
+        table_data.reset_index(inplace=True)
+        # select the data for the rows with appear in issue_df and get the child ids
+        linker_df = table_data.iloc[table_rows][["LAchildID", "ROW_ID"]]
+
+        # work around: ensure that columns from both sourcing have the same type to prevent merge error
+        table_df["ROW_ID"] = table_df["ROW_ID"].astype("int64")
+        linker_df["ROW_ID"] = linker_df["ROW_ID"].astype("int64")
+        # map the child ids back to issue_df
+        table_df = table_df.merge(linker_df, on=["ROW_ID"], how="left")
+
+        # save the result
+        tables_with_childid.append(table_df)
+
+    # regenerate issue_df from its updated constituent tables
+    issue_df = pd.concat(tables_with_childid)
+
+    return issue_df

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -56,7 +56,6 @@ class CinValidationSession:
         self.issue_id = issue_id
 
         self.create_error_report_df()
-        self.create_json_report()
         self.select_by_id()
 
     def create_error_report_df(self):
@@ -136,11 +135,6 @@ class CinValidationSession:
             self.rule_descriptors = pd.concat([child_level_rules, la_level_rules])
         else:
             self.rule_descriptors = child_level_rules
-
-    def create_json_report(self):
-        """Creates JSONs of error report and rule descriptors dfs."""
-        self.json_issue_report = self.all_rules_issue_locs.to_json(orient="records")
-        self.json_rule_descriptors = self.rule_descriptors.to_json(orient="records")
 
     def select_by_id(self):
         if self.issue_id is not None:

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -44,8 +44,11 @@ def cin_validate(cin_data, ruleset="rules.cin2022_23"):
     validator = cin_class.CinValidationSession(data_files, ruleset)
     raw_data = cin_class.process_data(root, as_dict=True)
 
+    issue_df = validator.all_rules_issue_locs
+    issue_df = cin_class.include_issue_child(issue_df, raw_data)
+
     # make return data json-serialisable
-    issue_report = validator.all_rules_issue_locs.to_json(orient="records")
+    issue_report = issue_df.to_json(orient="records")
     rule_defs = validator.rule_descriptors.to_json(orient="records")
     json_data_files = {
         table_name: table_df.to_json(orient="records")

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -45,8 +45,8 @@ def cin_validate(cin_data, ruleset="rules.cin2022_23"):
     raw_data = cin_class.process_data(root, as_dict=True)
 
     # make return data json-serialisable
-    issue_report = validator.json_issue_report
-    rule_defs = validator.json_rule_descriptors
+    issue_report = validator.all_rules_issue_locs.to_json(orient="records")
+    rule_defs = validator.rule_descriptors.to_json(orient="records")
     json_data_files = {
         table_name: table_df.to_json(orient="records")
         for table_name, table_df in raw_data.items()


### PR DESCRIPTION
All rows in issue report now have an associated childID except

- rows flagged by LA-level rules which are flagged for the whole local authority and are not associated with any child.
- rows flagged in the Header table. The Header table does not contain child information so there is no child ID. It is metadata-like.