### PR TITLE
feature/select rules

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -40,7 +40,9 @@ The Header contains the metadata including collection_year and census type. If C
 ## Validation: cin_validate
 This is the default feature. File input is converted into tabular-format (dataframes) and the data is validated based on rules [defined by the DfE](https://www.gov.uk/government/publications/children-in-need-census-2022-to-2023-specification) and coded in the `rules` folder.
 
-The `cin_validate` function receives two arguments: a reference to the xml file that needs to be validated and an optional choice of which rule pack to run. The second parameter (ruleset) will only need to be changed if the user choses to validate their data based on the rules of a year different from the one they're in.
+The `cin_validate` function receives three arguments: a reference to the xml file that needs to be validated, an optional choice of rules, and an optional choice of which rule pack to run. The third parameter (ruleset) will only need to be changed if the user choses to validate their data based on the rules of a year different from the one they're in.
+
+The `selected_rules` parameter works with a single string or an array (list/tuple) of strings where each value is a rule code that the user chose to run in the frontend.
 
 The validation process returns an issue report, rule definitions of only the rules that triggered issues, and a tabular format of the CIN data it received.
 

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -47,8 +47,9 @@ def list_cmd(ruleset):
     help="Which ruleset to use, e.g. rules.cin2022_23",
 )
 @click.option("--issue_id", "-e", default=None)
+@click.option("--select", "-s", default=None)
 @click.option("--output/--no_output", "-o/-no", default=False)
-def run_all(filename: str, ruleset, issue_id, output):
+def run_all(filename: str, ruleset, issue_id, select, output):
     """
     Used to run all of a set of validation rules on input data.
 
@@ -73,7 +74,9 @@ def run_all(filename: str, ruleset, issue_id, output):
     root = fulltree.getroot()
 
     data_files = cin_class.process_data(root)
-    validator = cin_class.CinValidationSession(data_files, ruleset, issue_id)
+    validator = cin_class.CinValidationSession(
+        data_files, ruleset, issue_id, selected_rules=select
+    )
 
     issue_instances = validator.issue_instances
     all_rules_issue_locs = validator.all_rules_issue_locs

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -93,6 +93,56 @@ class CinValidationSession:
         self.create_issue_report_df()
         self.select_by_id()
 
+    def process_issues(self, rule, ctx):
+        # TODO is it wiser to split the rules according to types instead of checking the type each time a rule is run?.
+        issue_dfs_per_rule = pd.Series(
+            [
+                ctx.type_zero_issues,
+                ctx.type_one_issues,
+                ctx.type_two_issues,
+                ctx.type_three_issues,
+                ctx.la_level_issues,
+            ]
+        )
+        # error_df_lengths is a list of lengths of all elements in issue_dfs_per_rule respectively.
+        error_df_lengths = pd.Series([len(x) for x in issue_dfs_per_rule])
+        if error_df_lengths.max() == 0:
+            # if the rule didn't push to any of the issue accumulators, then it didn't find any issues in the file.
+            self.rules_passed.append(rule.code)
+        elif error_df_lengths.max() == 4:
+            # this is a return level validation rule. It has no locations attached so it is only displayed in the rule descriptions.
+            self.la_rules_broken.append(issue_dfs_per_rule[4])
+        else:
+            # get the rule type based on which attribute had elements pushed to it (i.e non-zero length)
+            # its corresponding error_df can be found by issue_dfs_per_rule[ind]
+            ind = error_df_lengths.idxmax()
+
+            issue_dict = {
+                "code": rule.code,
+                "number": error_df_lengths[ind],
+                "type": ind,
+            }
+            issue_dict_df = pd.DataFrame([issue_dict])
+            self.issue_instances = pd.concat(
+                [self.issue_instances, issue_dict_df], ignore_index=True
+            )
+
+            # add a the rule's code to it's error_df
+            issue_dfs_per_rule[ind]["rule_code"] = rule.code
+
+            # temporary: add rule type to track if all types are in df.
+            issue_dfs_per_rule[ind]["rule_type"] = ind
+
+            # combine this rule's error_df with the cummulative error_df
+            self.all_rules_issue_locs = pd.concat(
+                [self.all_rules_issue_locs, issue_dfs_per_rule[ind]],
+                ignore_index=True,
+            )
+
+            # Elements of the rule_descriptors df to explain error codes
+            self.rules_broken.append(rule.code)
+            self.rule_messages.append(f"{str(rule.code)} - {rule.message}")
+
     def create_issue_report_df(self):
         """
         Creates report of errors found when validating CIN data input to
@@ -129,60 +179,12 @@ class CinValidationSession:
 
         for rule in registry:
             data_files = self.data_files.__deepcopy__({})
+            ctx = RuleContext(rule)
             try:
-                ctx = RuleContext(rule)
                 rule.func(data_files, ctx)
-                # TODO is it wiser to split the rules according to types instead of checking the type each time a rule is run?.
-                issue_dfs_per_rule = pd.Series(
-                    [
-                        ctx.type_zero_issues,
-                        ctx.type_one_issues,
-                        ctx.type_two_issues,
-                        ctx.type_three_issues,
-                        ctx.la_level_issues,
-                    ]
-                )
-                # error_df_lengths is a list of lengths of all elements in issue_dfs_per_rule respectively.
-                error_df_lengths = pd.Series([len(x) for x in issue_dfs_per_rule])
-                if error_df_lengths.max() == 0:
-                    # if the rule didn't push to any of the issue accumulators, then it didn't find any issues in the file.
-                    self.rules_passed.append(rule.code)
-                elif error_df_lengths.max() == 4:
-                    # this is a return level validation rule. It has no locations attached so it is only displayed in the rule descriptions.
-                    self.la_rules_broken.append(issue_dfs_per_rule[4])
-                else:
-                    # get the rule type based on which attribute had elements pushed to it (i.e non-zero length)
-                    # its corresponding error_df can be found by issue_dfs_per_rule[ind]
-                    ind = error_df_lengths.idxmax()
-
-                    issue_dict = {
-                        "code": rule.code,
-                        "number": error_df_lengths[ind],
-                        "type": ind,
-                    }
-                    issue_dict_df = pd.DataFrame([issue_dict])
-                    self.issue_instances = pd.concat(
-                        [self.issue_instances, issue_dict_df], ignore_index=True
-                    )
-
-                    # add a the rule's code to it's error_df
-                    issue_dfs_per_rule[ind]["rule_code"] = rule.code
-
-                    # temporary: add rule type to track if all types are in df.
-                    issue_dfs_per_rule[ind]["rule_type"] = ind
-
-                    # combine this rule's error_df with the cummulative error_df
-                    self.all_rules_issue_locs = pd.concat(
-                        [self.all_rules_issue_locs, issue_dfs_per_rule[ind]],
-                        ignore_index=True,
-                    )
-
-                    # Elements of the rule_descriptors df to explain error codes
-                    self.rules_broken.append(rule.code)
-                    self.rule_messages.append(f"{str(rule.code)} - {rule.message}")
-
             except Exception as e:
                 print(f"Error with rule {rule.code}: {type(e).__name__}, {e}")
+            self.process_issues(rule, ctx)
 
         # df of all broken rule codes and related error messages.
         child_level_rules = pd.DataFrame(

--- a/create_rule_list.py
+++ b/create_rule_list.py
@@ -12,7 +12,7 @@ for rule in registry:
     )
 
 all_rules = pd.DataFrame(all_rules)
-all_rules = all_rules.to_dict(orient="records")
+all_rules = all_rules.to_json(orient="records")
 
 with open("write_all_rules.json", "w") as f:
     json.dump(all_rules, f)

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -28,9 +28,10 @@ def generate_tables(cin_data):
 
 
 @app.call
-def cin_validate(cin_data, ruleset="rules.cin2022_23"):
+def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     """
-    :param cin_data: file reference to a CIN XML file
+    :param file-ref cin_data: file reference to a CIN XML file
+    :param list selected_rules: array of rules the user has chosen. consists of rule codes as strings.
     :param ruleset: rule pack that should be run. cin2022_23 is for the year 2022
 
     :return issue_report: issue locations in the data.
@@ -41,7 +42,9 @@ def cin_validate(cin_data, ruleset="rules.cin2022_23"):
     root = ET.fromstring(filetext)
 
     data_files = cin_class.process_data(root)
-    validator = cin_class.CinValidationSession(data_files, ruleset)
+    validator = cin_class.CinValidationSession(
+        data_files, ruleset, selected_rules=selected_rules
+    )
     raw_data = cin_class.process_data(root, as_dict=True)
 
     issue_df = validator.all_rules_issue_locs


### PR DESCRIPTION
The changes in this pull request allow the a sub-list of the existing rules to be run on the data, based on the user's preference.
A `selected_rules` argument has been added to the `cin_validate` api function. It can accept a single string value or a list of strings where each string represents a rule code.

Other changes include further modularising of code to split up the large for loop that existed in the `create_error_report` function.