### PR TITLE
Fix dateofinitialcpc bug

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_2990.py
+++ b/cin_validator/rules/cin2022_23/rule_2990.py
@@ -69,7 +69,7 @@ def validate(
     )
 
     df_cin_47 = df_cin.merge(
-        df_47, on=["LAchildID", "CINdetailsID"], how="left", suffixes=["_cin", "_47"]
+        df_47, on=["LAchildID", "CINdetailsID", DateOfInitialCPC], how="left", suffixes=["_cin", "_47"]
     )
 
     df_cin_cin_pd = df_cin.merge(
@@ -89,7 +89,7 @@ def validate(
             "ReasonForClosure",
         ],
         how="left",
-        suffixes=["", ""],
+        suffixes=["_cin_cpp", "_cin_47"],
     )
     merged_df = df_cin_cpp_47.merge(
         df_cin_cin_pd,
@@ -101,7 +101,7 @@ def validate(
             "ReasonForClosure",
         ],
         how="left",
-        suffixes=["", ""],
+        suffixes=["_cin_cpp_47", "_cin_cin_pd"],
     )
 
     # Logical conditions - other than this, of the tables can merge, it means there's modules and they are in error
@@ -206,30 +206,37 @@ def test_validate():
         [
             {
                 "LAchildID": "child1",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID2",
             },
             {
                 "LAchildID": "child2",  # fails for having a module
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID2",
             },
             {
                 "LAchildID": "child2",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID1",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID1",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": "26/05/2000",
                 "CINdetailsID": "cinID2",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID3",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": "14/03/2001",
                 "CINdetailsID": "cinID4",
             },
         ]
@@ -310,6 +317,9 @@ def test_validate():
 
     sample_cin_details["DateOfInitialCPC"] = pd.to_datetime(
         sample_cin_details["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
+    )
+    sample_section47["DateOfInitialCPC"] = pd.to_datetime(
+        sample_section47["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
     )
 
     # Run the rule function, passing in our sample data.

--- a/cin_validator/rules/cin2022_23/rule_2990.py
+++ b/cin_validator/rules/cin2022_23/rule_2990.py
@@ -69,7 +69,10 @@ def validate(
     )
 
     df_cin_47 = df_cin.merge(
-        df_47, on=["LAchildID", "CINdetailsID", DateOfInitialCPC], how="left", suffixes=["_cin", "_47"]
+        df_47,
+        on=["LAchildID", "CINdetailsID", DateOfInitialCPC],
+        how="left",
+        suffixes=["_cin", "_47"],
     )
 
     df_cin_cin_pd = df_cin.merge(

--- a/cin_validator/rules/cin2022_23/rule_8565.py
+++ b/cin_validator/rules/cin2022_23/rule_8565.py
@@ -127,13 +127,23 @@ def validate(
     df = (
         df_CIN_assessments.merge(
             df_CIN_S47,
-            on=[
+            left_on=[
                 LAchildID,
                 CINdetailsID,
                 "ROW_ID_CIN",
                 CINclosureDate,
-                DateOfInitialCPC,
+                "DateOfInitialCPC"
             ],
+            right_on = [
+                 LAchildID,
+                CINdetailsID,
+                "ROW_ID_CIN",
+                CINclosureDate,
+                "DateOfInitialCPC_CIN"               
+            ],
+            # left_on = ["DateOfInitialCPC_CIN"],
+            # right_on = [DateOfInitialCPC],
+            suffixes = ("_dd", "_done")
         )
         .merge(
             df_CIN_CPP,
@@ -397,48 +407,56 @@ def test_validate():
                 "LAchildID": "child1",
                 "CINdetailsID": "cinID1",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Pass
             },
             {
                 "LAchildID": "child2",
                 "CINdetailsID": "cinID2",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Fails on initial CPC date
             },
             {
                 "LAchildID": "child3",
                 "CINdetailsID": "cinID3",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Fails on assessment start date
             },
             {
                 "LAchildID": "child4",
                 "CINdetailsID": "cinID4",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Fails on assessment authorisation date
             },
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID5",
-                "S47ActualStartDate": "31/07/2022",  # Fails S47 starts after CIN closure
+                "S47ActualStartDate": "31/07/2022", 
+                "DateOfInitialCPC": "30/12/2020" # Fails S47 starts after CIN closure
                 # Fail
             },
             {
                 "LAchildID": "child6",
                 "CINdetailsID": "cinID6",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Fails on CPP start date
             },
             {
                 "LAchildID": "child7",
                 "CINdetailsID": "cinID7",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Fails on CIN plan start date
             },
             {
                 "LAchildID": "child8",
                 "CINdetailsID": "cinID8",
                 "S47ActualStartDate": "01/01/2021",
+                "DateOfInitialCPC": "30/12/2020"
                 # Fails on CIN plan end date
             },
         ]

--- a/cin_validator/rules/cin2022_23/rule_8565.py
+++ b/cin_validator/rules/cin2022_23/rule_8565.py
@@ -132,18 +132,18 @@ def validate(
                 CINdetailsID,
                 "ROW_ID_CIN",
                 CINclosureDate,
-                "DateOfInitialCPC"
+                "DateOfInitialCPC",
             ],
-            right_on = [
-                 LAchildID,
+            right_on=[
+                LAchildID,
                 CINdetailsID,
                 "ROW_ID_CIN",
                 CINclosureDate,
-                "DateOfInitialCPC_CIN"               
+                "DateOfInitialCPC_CIN",
             ],
             # left_on = ["DateOfInitialCPC_CIN"],
             # right_on = [DateOfInitialCPC],
-            suffixes = ("_dd", "_done")
+            suffixes=("_dd", "_done"),
         )
         .merge(
             df_CIN_CPP,
@@ -434,8 +434,8 @@ def test_validate():
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID5",
-                "S47ActualStartDate": "31/07/2022", 
-                "DateOfInitialCPC": "30/12/2020" # Fails S47 starts after CIN closure
+                "S47ActualStartDate": "31/07/2022",
+                "DateOfInitialCPC": "30/12/2020"  # Fails S47 starts after CIN closure
                 # Fail
             },
             {

--- a/cin_validator/rules/cin2022_23/rule_8831.py
+++ b/cin_validator/rules/cin2022_23/rule_8831.py
@@ -70,16 +70,19 @@ def validate(
 
     # Check columns in Section47 table
     df_cin_47 = df_cin.merge(
-        df_47, on=["LAchildID", "CINdetailsID", "DateOfInitialCPC"], how="left", suffixes=["_cin", "_47"]
+        df_47,
+        on=["LAchildID", "CINdetailsID", "DateOfInitialCPC"],
+        how="left",
+        suffixes=["_cin", "_47"],
     )
     # filter out rows that have an S47ActualStartDate or DateOfInitialCPC
     condition_1 = (
         df_cin_47[DateOfInitialCPC].notna() | df_cin_47[S47ActualStartDate].notna()
     )
     df_cin_47 = df_cin_47[condition_1]
-    
+
     df_cin_47["ERROR_ID"] = tuple(zip(df_cin_47[LAchildID], df_cin_47[CINdetailsID]))
-    
+
     df_47_issues = (
         df_47.merge(df_cin_47, left_on="ROW_ID", right_on="ROW_ID_47")
         .groupby("ERROR_ID", group_keys=False)["ROW_ID"]

--- a/cin_validator/rules/cin2022_23/rule_8831.py
+++ b/cin_validator/rules/cin2022_23/rule_8831.py
@@ -70,14 +70,16 @@ def validate(
 
     # Check columns in Section47 table
     df_cin_47 = df_cin.merge(
-        df_47, on=["LAchildID", "CINdetailsID"], how="left", suffixes=["_cin", "_47"]
+        df_47, on=["LAchildID", "CINdetailsID", "DateOfInitialCPC"], how="left", suffixes=["_cin", "_47"]
     )
     # filter out rows that have an S47ActualStartDate or DateOfInitialCPC
     condition_1 = (
         df_cin_47[DateOfInitialCPC].notna() | df_cin_47[S47ActualStartDate].notna()
     )
     df_cin_47 = df_cin_47[condition_1]
+    
     df_cin_47["ERROR_ID"] = tuple(zip(df_cin_47[LAchildID], df_cin_47[CINdetailsID]))
+    
     df_47_issues = (
         df_47.merge(df_cin_47, left_on="ROW_ID", right_on="ROW_ID_47")
         .groupby("ERROR_ID", group_keys=False)["ROW_ID"]
@@ -137,31 +139,38 @@ def test_validate():
         [
             {
                 "LAchildID": "child1",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID2",
             },
             {
                 "LAchildID": "child2",  # fails for having a module
                 "CINdetailsID": "cinID2",
+                "DateOfInitialCPC": pd.NA,
                 "S47ActualStartDate": "01/01/2000",
             },
             {
                 "LAchildID": "child2",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID1",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID1",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID2",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID3",
             },
             {
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID4",
             },
         ]
@@ -250,6 +259,9 @@ def test_validate():
 
     sample_cin_details["DateOfInitialCPC"] = pd.to_datetime(
         sample_cin_details["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
+    )
+    sample_section47["DateOfInitialCPC"] = pd.to_datetime(
+        sample_section47["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
     )
     sample_section47["S47ActualStartDate"] = pd.to_datetime(
         sample_section47["S47ActualStartDate"], format="%d/%m/%Y", errors="coerce"

--- a/cin_validator/rules/cin2022_23/rule_8868.py
+++ b/cin_validator/rules/cin2022_23/rule_8868.py
@@ -54,18 +54,24 @@ def validate(
 
     merged_df = CINclosure_present.merge(
         df_47,
-        on=[LAchildID, "CINdetailsID"],
+        on=[LAchildID, "CINdetailsID", DateOfInitialCPC],
         how="left",
         suffixes=["_cin", "_47"],
     )
 
-    oneortrue = ["1", "true"]
-    condition = (merged_df[DateOfInitialCPC].isna()) & (
-        ~merged_df[ICPCnotRequired].isin(oneortrue)
+    # condition = (merged_df[DateOfInitialCPC].isna()) & (
+    #    ~merged_df[ICPCnotRequired].isin(oneortrue)
+    # )
+
+    condition_1 = (merged_df[DateOfInitialCPC].isna()) & (
+        ~merged_df[ICPCnotRequired].isin(["1", "true"])
+    )
+    condition_2 = (merged_df[DateOfInitialCPC].notna()) & (
+        merged_df[ICPCnotRequired].isin(["1", "true"])
     )
 
     # get all the data that fits the failing condition.
-    merged_df = merged_df[condition].reset_index()
+    merged_df = merged_df[condition_1 | condition_2].reset_index()
 
     # create an identifier for each error instance.
     merged_df["ERROR_ID"] = tuple(zip(merged_df[LAchildID], merged_df[CINdetailsID]))
@@ -121,7 +127,7 @@ def test_validate():
             {
                 "LAchildID": "child3",
                 "DateOfInitialCPC": "27/05/2000",  # 3 pass DateOfInitialCPC present
-                "ICPCnotRequired": "true",
+                "ICPCnotRequired": "false",
                 "CINdetailsID": "cinID1",
             },
             {
@@ -150,36 +156,43 @@ def test_validate():
                 "LAchildID": "child1",  # 0 fail: contains a section47 group that fails.
                 "CINclosureDate": "26/10/1999",
                 "CINdetailsID": "cinID1",
+                "DateOfInitialCPC": pd.NA,
             },
             {
                 "LAchildID": "child1",  # 1 pass
                 "CINclosureDate": "26/05/2000",
                 "CINdetailsID": "cinID2",
+                "DateOfInitialCPC": pd.NA,
             },
             {
                 "LAchildID": "child2",  # 2
                 "CINclosureDate": "26/05/2000",
                 "CINdetailsID": "cinID1",
+                "DateOfInitialCPC": pd.NA,
             },
             {
                 "LAchildID": "child3",  # 3 pass
                 "CINclosureDate": "28/05/2000",
                 "CINdetailsID": "cinID1",
+                "DateOfInitialCPC": "27/05/2000",
             },
             {
                 "LAchildID": "child3",  # 4 fail: contains a section47 group that fails.
                 "CINclosureDate": "26/05/2000",
                 "CINdetailsID": "cinID2",
+                "DateOfInitialCPC": "26/05/2000",
             },
             {
                 "LAchildID": "child3",  # 5 fail. not present in section47 table so none of the values meets the requirements
                 "CINclosureDate": "26/05/2003",
                 "CINdetailsID": "cinID3",
+                "DateOfInitialCPC": pd.NA,
             },
             {
                 "LAchildID": "child4",
                 "CINclosureDate": pd.NA,  # 6 ignore: date absent
                 "CINdetailsID": "cinID4",
+                "DateOfInitialCPC": pd.NA,
             },
         ]
     )
@@ -189,6 +202,9 @@ def test_validate():
     )
     sample_section47["DateOfInitialCPC"] = pd.to_datetime(
         sample_section47["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
+    )
+    sample_cin["DateOfInitialCPC"] = pd.to_datetime(
+        sample_cin["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
     )
 
     # Run the rule function, passing in our sample data.


### PR DESCRIPTION
closes #292 

Tables both containing DateOfInitialCPC were merged, not on DateOfInitialCPC, but then DateOfInitialCPC was used without suffixes. DateOfInitialCPC was also not present in sample dataframes allowing tests to pass.

DateOfInitialCPC added to sample DFs and Merges correctly done using DateOfInitialCPC.