### PR TITLE
Fix 8816 - ValueError: attempt to get argmax of an empty sequence

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8816.py
+++ b/cin_validator/rules/cin2022_23/rule_8816.py
@@ -142,6 +142,20 @@ def test_validate():
                 "CINdetailsID": "cinID3",
                 "ReferralNFA": "0",
             },
+            {
+                "LAchildID": "child4",
+                "CINclosureDate": pd.NA,
+                "CINreferralDate": pd.NA,
+                "CINdetailsID": "cinID3",
+                "ReferralNFA": "0",
+            },
+            {
+                "LAchildID": "child4",
+                "CINclosureDate": pd.NA,
+                "CINreferralDate": pd.NA,
+                "CINdetailsID": "cinID4",
+                "ReferralNFA": "0",
+            },
         ]
     )
 

--- a/cin_validator/rules/cin2022_23/rule_8816.py
+++ b/cin_validator/rules/cin2022_23/rule_8816.py
@@ -45,6 +45,9 @@ def validate(
     # <ReferralNFA> (N00112) = false or 0
     # then the <CINreferralDate> (N00100) for this module must be the latest of all Referral Dates for that child.
 
+    # removing nans prevents ValueError: attempt to get argmax of an empty sequence, when no CINreferralDate is present
+    df_cin = df_cin[df_cin[CINreferralDate].notna()]
+
     # find out the latest referral date (and its index position) for each child and attach it to all the rows for that child.
     df_cin["latest_referral"] = df_cin.groupby(LAchildID)[CINreferralDate].transform(
         "max"


### PR DESCRIPTION
Children with no CINreferralDate raised this error. The fix filters out nan values before finding the latest referral such that the maximum value of an empty sequence never needs to be found.