### PR TITLE
debug/issue_report: row_id as integers

### DIFF
--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -260,7 +260,8 @@ def include_issue_child(issue_df, cin_data):
         table_df = issue_df[issue_df["tables_affected"] == table]
 
         # get index values of the rows that fail.
-        table_rows = table_df["ROW_ID"].unique()
+        # some ROW_ID values exist as ints and others as strs. Unify so that .unique() doesn't contain doubles.
+        table_rows = table_df["ROW_ID"].astype("int").unique()
 
         # naming the index of the data allows it to be mapped back to the issue_df
         table_data = cin_data[table]


### PR DESCRIPTION
When unique row IDs were filtered in the include_child_id function of the cin_validator_class module, it included doubles because of a variation in data types among ROW_ID values. As such "0"(str) was seen as different from 0 (integer). This caused a number of double in the result.

The changes in this pull request prevent doubles from happening when unique rows are filtered by typecasting the ROW_ID column before filtering.