### PR TITLE
Refactor/remove data container

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -73,7 +73,7 @@ def run_all(filename: str, ruleset, issue_id, select, output):
     fulltree = ET.parse(filename)
     root = fulltree.getroot()
 
-    data_files = cin_class.process_data(root)
+    data_files = cin_class.process_data(root, as_dict=True)
     validator = cin_class.CinValidationSession(
         data_files, ruleset, issue_id, selected_rules=select
     )

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -73,7 +73,7 @@ def run_all(filename: str, ruleset, issue_id, select, output):
     fulltree = ET.parse(filename)
     root = fulltree.getroot()
 
-    data_files = cin_class.process_data(root, as_dict=True)
+    data_files = cin_class.process_data(root)
     validator = cin_class.CinValidationSession(
         data_files, ruleset, issue_id, selected_rules=select
     )
@@ -168,7 +168,7 @@ def cli_converter(filename: str):
         fulltree = ET.parse(filename)
         root = fulltree.getroot()
 
-        cin_tables_dict = cin_class.process_data(root, as_dict=True)
+        cin_tables_dict = cin_class.process_data(root)
         for k, v in cin_tables_dict.items():
             #  TODO output CSVs as a zip file
             filepath = Path(f"output_csvs/{k}.csv")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -79,11 +79,11 @@ def run_all(filename: str, ruleset, issue_id, select, output):
     )
 
     issue_instances = validator.issue_instances
-    all_rules_issue_locs = validator.all_rules_issue_locs
+    all_rules_issue_locs = validator.full_issue_df
 
     if output:
         # TODO when dict of dfs can be passed into this class, run include_issue_child on issue_report
-        issue_report = validator.all_rules_issue_locs.to_json(orient="records")
+        issue_report = validator.full_issue_df.to_json(orient="records")
         rule_defs = validator.rule_descriptors.to_json(orient="records")
 
         # generating sample files for the frontend.

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -1,10 +1,23 @@
+import copy
 import importlib
 
 import pandas as pd
 
 from cin_validator.ingress import XMLtoCSV
-from cin_validator.rule_engine import RuleContext, registry
+from cin_validator.rule_engine import CINTable, RuleContext, registry
 from cin_validator.utils import DataContainerWrapper, process_date_columns
+
+
+def enum_keys(dict_input):
+    """
+    Convert keys of a dictionary to its corresponding CINTable format.
+    :param dict dict_input: dictionary of dataframes of CIN data
+    :return dict enumed_dict: same data content with keys replaced.
+    """
+    enumed_dict = {}
+    for enum_key in CINTable:
+        enumed_dict[enum_key] = dict_input[str(enum_key)[9:]]
+    return enumed_dict
 
 
 def process_data(root, as_dict=False):
@@ -194,6 +207,7 @@ class CinValidationSession:
         :raises: Errors with rules that raise errors when validating data.
         """
 
+        enum_data_files = enum_keys(self.data_files)
         self.issue_instances = pd.DataFrame()
         self.all_rules_issue_locs = pd.DataFrame()
         self.rules_passed = []
@@ -206,7 +220,8 @@ class CinValidationSession:
 
         rules_to_run = self.get_rules_to_run(registry, selected_rules)
         for rule in rules_to_run:
-            data_files = self.data_files.__deepcopy__({})
+            # data_files = self.data_files.__deepcopy__({})
+            data_files = copy.deepcopy(enum_data_files)
             ctx = RuleContext(rule)
             try:
                 rule.func(data_files, ctx)

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from cin_validator.ingress import XMLtoCSV
 from cin_validator.rule_engine import CINTable, RuleContext, registry
-from cin_validator.utils import DataContainerWrapper, process_date_columns
+from cin_validator.utils import process_date_columns
 
 
 def enum_keys(dict_input):
@@ -20,7 +20,7 @@ def enum_keys(dict_input):
     return enumed_dict
 
 
-def process_data(root, as_dict=False):
+def process_data(root):
     """
     Takes input data and processes it for validation.
 
@@ -36,40 +36,27 @@ def process_data(root, as_dict=False):
 
     # generate tables
     data_files = XMLtoCSV(root)
-    tables = [
-        data_files.Header,
-        data_files.ChildIdentifiers,
-        data_files.ChildCharacteristics,
-        data_files.ChildProtectionPlans,
-        data_files.CINdetails,
-        data_files.CINplanDates,
-        data_files.Reviews,
-        data_files.Section47,
-        data_files.Assessments,
-        data_files.Disabilities,
-    ]
-    # format all date columns in tables
-    for df in tables:
-        process_date_columns(df)
 
     # return tables
-    if as_dict:
-        cin_tables_dict = {
-            "Header": data_files.Header,
-            "ChildIdentifiers": data_files.ChildIdentifiers,
-            "ChildCharacteristics": data_files.ChildCharacteristics,
-            "ChildProtectionPlans": data_files.ChildProtectionPlans,
-            "CINdetails": data_files.CINdetails,
-            "CINplanDates": data_files.CINplanDates,
-            "Reviews": data_files.Reviews,
-            "Section47": data_files.Section47,
-            "Assessments": data_files.Assessments,
-            "Disabilities": data_files.Disabilities,
-        }
-        return cin_tables_dict
-    else:
-        data_files_obj = DataContainerWrapper(data_files)
-        return data_files_obj
+    cin_tables = {
+        "Header": data_files.Header,
+        "ChildIdentifiers": data_files.ChildIdentifiers,
+        "ChildCharacteristics": data_files.ChildCharacteristics,
+        "ChildProtectionPlans": data_files.ChildProtectionPlans,
+        "CINdetails": data_files.CINdetails,
+        "CINplanDates": data_files.CINplanDates,
+        "Reviews": data_files.Reviews,
+        "Section47": data_files.Section47,
+        "Assessments": data_files.Assessments,
+        "Disabilities": data_files.Disabilities,
+    }
+
+    # format all date columns in tables
+    cin_tables_dict = {
+        name: process_date_columns(table) for name, table in cin_tables.items()
+    }
+
+    return cin_tables_dict
 
 
 class CinValidationSession:

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -145,9 +145,7 @@ class CinValidationSession:
         self.select_by_id()
 
         # add child_id to issue location report.
-        self.all_rules_issue_locs = include_issue_child(
-            self.all_rules_issue_locs, raw_data
-        )
+        self.full_issue_df = include_issue_child(self.full_issue_df, raw_data)
 
     def get_rules_to_run(self, registry, selected_rules):
         """
@@ -212,8 +210,8 @@ class CinValidationSession:
             issue_dfs_per_rule[ind]["rule_type"] = ind
 
             # combine this rule's error_df with the cummulative error_df
-            self.all_rules_issue_locs = pd.concat(
-                [self.all_rules_issue_locs, issue_dfs_per_rule[ind]],
+            self.full_issue_df = pd.concat(
+                [self.full_issue_df, issue_dfs_per_rule[ind]],
                 ignore_index=True,
             )
 
@@ -247,7 +245,7 @@ class CinValidationSession:
 
         enum_data_files = enum_keys(self.data_files)
         self.issue_instances = pd.DataFrame()
-        self.all_rules_issue_locs = pd.DataFrame()
+        self.full_issue_df = pd.DataFrame()
         self.rules_passed = []
 
         self.rules_broken = []
@@ -290,8 +288,8 @@ class CinValidationSession:
 
         if self.issue_id is not None:
             self.issue_id = tuple(self.issue_id.split(", "))
-            self.all_rules_issue_locs = self.all_rules_issue_locs[
-                self.all_rules_issue_locs["ERROR_ID"] == self.issue_id
+            self.full_issue_df = self.full_issue_df[
+                self.full_issue_df["ERROR_ID"] == self.issue_id
             ]
         else:
             pass

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -16,7 +16,8 @@ def enum_keys(dict_input):
     """
     enumed_dict = {}
     for enum_key in CINTable:
-        enumed_dict[enum_key] = dict_input[str(enum_key)[9:]]
+        # if enum_key == CINTable.Header, then enum_key.name == Header
+        enumed_dict[enum_key] = dict_input[str(enum_key.name)]
     return enumed_dict
 
 
@@ -59,6 +60,47 @@ def process_data(root):
     return cin_tables_dict
 
 
+def include_issue_child(issue_df, cin_data):
+    """
+    :param DataFrame issue_df: complete data about all issue locations.
+    :param dict cin_data: dictionary of dataframes generated when cin xml is converted to tabular format.
+    """
+
+    la_level_issues = issue_df[issue_df["tables_affected"].isna()]
+    header_issues = issue_df[issue_df["tables_affected"] == "Header"]
+    tables_with_childid = [la_level_issues, header_issues]
+    for table in issue_df["tables_affected"].dropna().unique():
+        if table == "Header":
+            # the header table doesn't contain child id. It is like metadata
+            continue
+        table_df = issue_df[issue_df["tables_affected"] == table]
+
+        # get index values of the rows that fail.
+        # some ROW_ID values exist as ints and others as strs. Unify so that .unique() doesn't contain doubles.
+        table_rows = table_df["ROW_ID"].astype("int").unique()
+
+        # naming the index of the data allows it to be mapped back to the issue_df
+        table_data = cin_data[table]
+        table_data.index.name = "ROW_ID"
+        table_data.reset_index(inplace=True)
+        # select the data for the rows with appear in issue_df and get the child ids
+        linker_df = table_data.iloc[table_rows][["LAchildID", "ROW_ID"]]
+
+        # work around: ensure that columns from both sources have the same type to prevent merge error
+        table_df["ROW_ID"] = table_df["ROW_ID"].astype("int64")
+        linker_df["ROW_ID"] = linker_df["ROW_ID"].astype("int64")
+        # map the child ids back to issue_df
+        table_df = table_df.merge(linker_df, on=["ROW_ID"], how="left")
+
+        # save the result
+        tables_with_childid.append(table_df)
+
+    # regenerate issue_df from its updated constituent tables
+    issue_df = pd.concat(tables_with_childid)
+
+    return issue_df
+
+
 class CinValidationSession:
     """
     A class to contain the process of CIN validation. Generates error reports as dataframes.
@@ -95,8 +137,17 @@ class CinValidationSession:
         self.ruleset = ruleset
         self.issue_id = issue_id
 
+        # save independent version of data to be used in report.
+        raw_data = copy.deepcopy(self.data_files)
+
+        # run
         self.create_issue_report_df(selected_rules)
         self.select_by_id()
+
+        # add child_id to issue location report.
+        self.all_rules_issue_locs = include_issue_child(
+            self.all_rules_issue_locs, raw_data
+        )
 
     def get_rules_to_run(self, registry, selected_rules):
         """
@@ -244,44 +295,3 @@ class CinValidationSession:
             ]
         else:
             pass
-
-
-def include_issue_child(issue_df, cin_data):
-    """
-    :param DataFrame issue_df: complete data about all issue locations.
-    :param dict cin_data: dictionary of dataframes generated when cin xml is converted to tabular format.
-    """
-
-    la_level_issues = issue_df[issue_df["tables_affected"].isna()]
-    header_issues = issue_df[issue_df["tables_affected"] == "Header"]
-    tables_with_childid = [la_level_issues, header_issues]
-    for table in issue_df["tables_affected"].dropna().unique():
-        if table == "Header":
-            # the header table doesn't contain child id. It is like metadata
-            continue
-        table_df = issue_df[issue_df["tables_affected"] == table]
-
-        # get index values of the rows that fail.
-        # some ROW_ID values exist as ints and others as strs. Unify so that .unique() doesn't contain doubles.
-        table_rows = table_df["ROW_ID"].astype("int").unique()
-
-        # naming the index of the data allows it to be mapped back to the issue_df
-        table_data = cin_data[table]
-        table_data.index.name = "ROW_ID"
-        table_data.reset_index(inplace=True)
-        # select the data for the rows with appear in issue_df and get the child ids
-        linker_df = table_data.iloc[table_rows][["LAchildID", "ROW_ID"]]
-
-        # work around: ensure that columns from both sources have the same type to prevent merge error
-        table_df["ROW_ID"] = table_df["ROW_ID"].astype("int64")
-        linker_df["ROW_ID"] = linker_df["ROW_ID"].astype("int64")
-        # map the child ids back to issue_df
-        table_df = table_df.merge(linker_df, on=["ROW_ID"], how="left")
-
-        # save the result
-        tables_with_childid.append(table_df)
-
-    # regenerate issue_df from its updated constituent tables
-    issue_df = pd.concat(tables_with_childid)
-
-    return issue_df

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -98,30 +98,6 @@ def create_issue_locs(issues):
     return df_issue_locs
 
 
-class DataContainerWrapper:
-    def __init__(self, value) -> None:
-        self.value = value
-
-    def __getitem__(self, name):
-        # converts all atributes, of the class input, to key-value pairs in a dictionary.
-        return getattr(self.value, name.name)
-
-    def __copy__(self):
-        cls = self.__class__
-        result = cls.__new__(cls)
-        result.__dict__.update(self.__dict__)
-        return result
-
-    def __deepcopy__(self, memo):
-        # the memo param is a dictionary that defines the parts of the class the should be shared between copies.
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        for k, v in self.__dict__.items():
-            setattr(result, k, deepcopy(v, memo))
-        return result
-
-
 def process_date_columns(df):
     """
     Takes a DataFrame in and converts all columns with Date or date in the

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -50,7 +50,7 @@ def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     validator = cin_class.CinValidationSession(
         data_files, ruleset, selected_rules=selected_rules
     )
-    issue_df = validator.all_rules_issue_locs
+    issue_df = validator.full_issue_df
 
     # make return data json-serialisable
     issue_report = issue_df.to_json(orient="records")

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -1,4 +1,3 @@
-import copy
 import xml.etree.ElementTree as ET
 
 from prpc_python import RpcApp
@@ -42,21 +41,19 @@ def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     filetext = cin_data.read().decode("utf-8")
     root = ET.fromstring(filetext)
 
-    raw_data = cin_class.process_data(root)
-    data_files = copy.deepcopy(raw_data)
+    data_files = cin_class.process_data(root)
+    json_data_files = {
+        table_name: table_df.to_json(orient="records")
+        for table_name, table_df in data_files.items()
+    }
+
     validator = cin_class.CinValidationSession(
         data_files, ruleset, selected_rules=selected_rules
     )
-
     issue_df = validator.all_rules_issue_locs
-    issue_df = cin_class.include_issue_child(issue_df, raw_data)
 
     # make return data json-serialisable
     issue_report = issue_df.to_json(orient="records")
     rule_defs = validator.rule_descriptors.to_json(orient="records")
-    json_data_files = {
-        table_name: table_df.to_json(orient="records")
-        for table_name, table_df in raw_data.items()
-    }
 
     return issue_report, rule_defs, json_data_files

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -1,3 +1,4 @@
+import copy
 import xml.etree.ElementTree as ET
 
 from prpc_python import RpcApp
@@ -16,7 +17,7 @@ def generate_tables(cin_data):
     filetext = cin_data.read().decode("utf-8")
     root = ET.fromstring(filetext)
 
-    data_files = cin_class.process_data(root, as_dict=True)
+    data_files = cin_class.process_data(root)
 
     # make data json-serialisable
     json_data_files = {
@@ -41,11 +42,11 @@ def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     filetext = cin_data.read().decode("utf-8")
     root = ET.fromstring(filetext)
 
-    data_files = cin_class.process_data(root)
+    raw_data = cin_class.process_data(root)
+    data_files = copy.deepcopy(raw_data)
     validator = cin_class.CinValidationSession(
         data_files, ruleset, selected_rules=selected_rules
     )
-    raw_data = cin_class.process_data(root, as_dict=True)
 
     issue_df = validator.all_rules_issue_locs
     issue_df = cin_class.include_issue_child(issue_df, raw_data)


### PR DESCRIPTION
> Sometimes DataContainerWrapper is used and other times a dictionary of dfs is needed. Can it always be a dict of dfs?.
> How do the enum declarations interact with this?.

The changes in this pull request unify the data conversion processes across the repo such that a dictionary of dataframes is always used to represent the CIN data.
