### PR TITLE
Fix/xml csv missing data

### DIFF
--- a/cin_validator/ingress.py
+++ b/cin_validator/ingress.py
@@ -246,6 +246,31 @@ class XMLtoCSV:
             [self.ChildCharacteristics, characteristics_df], ignore_index=True
         )
 
+        # The disabilities block for a child is found within a ChildCharacteristics block.
+        self.create_Disabilities(characteristics)
+
+    def create_Disabilities(self, characteristics):
+        """
+        Populates Disabilites table
+        """
+        disabilities_list = []
+        columns = self.Disabilities.columns
+        elements = list(set(columns).difference(set(self.id_cols)))
+        # get the Disabilities block
+        disabilities = characteristics.find("Disabilities")
+        for disability in disabilities:
+            disability_dict = {
+                "LAchildID": self.LAchildID,
+            }
+            disability_dict = get_values(elements, disability_dict, disability)
+            disability_dict["Disability"] = disability.text
+            disabilities_list.append(disability_dict)
+
+        disabilities_df = pd.DataFrame(disabilities_list)
+        self.Disabilities = pd.concat(
+            [self.Disabilities, disabilities_df], ignore_index=True
+        )
+
     # CINdetailsID needed
     def create_CINdetails(self, child):
         """Populates the CINdetails table. Multiple CIN details blocks can exist in one child.

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -112,15 +112,9 @@ def process_date_columns(df):
     """
 
     for column in df:
-        if ("date" in column) | ("Date" in column):
-            try:
-                df[column] = pd.to_datetime(
-                    df[column], format="%d/%m/%Y", errors="coerce"
-                )
-            except:
-                df[column] = pd.to_datetime(
-                    df[column], format="%Y/%m/%d", errors="coerce"
-                )
+        if "date" in column.lower():
+            # pd.to_datetime is intelligent. It can deal with unforseen date formats
+            df[column] = pd.to_datetime(df[column], errors="coerce")
     return df
 
 

--- a/demo_cin_tables.ipynb
+++ b/demo_cin_tables.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ingress import XMLtoCSV"
+    "from cin_validator.ingress import XMLtoCSV"
    ]
   },
   {
@@ -46,7 +46,7 @@
     "import xml.etree.ElementTree as ET\n",
     "\n",
     "# TODO make file path os-independent\n",
-    "fulltree = ET.parse(\"../fake_data/CIN_Census_2021.xml\")\n",
+    "fulltree = ET.parse(\"fake_data/CIN_Census_2021.xml\")\n",
     "# fulltree = ET.parse(\"../fake_data/fake_CIN_data.xml\")"
    ]
   },
@@ -191,9 +191,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Empty DataFrame\n",
-      "Columns: [LAchildID, Disability]\n",
-      "Index: []\n"
+      "     LAchildID Disability\n",
+      "0  DfEX0000001       HAND\n",
+      "1  DfEX0000001       HEAR\n"
      ]
     }
    ],
@@ -383,7 +383,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "                                                                                               Further questions? Ask Tambe\n"
+    "                                                                                            Further questions? Ask Tambe T.\n"
    ]
   }
  ],


### PR DESCRIPTION
Files data files generated by the process_data function in utils were all seen to have missing or null values in date columns.
The disabiliites table was blank when it wasn't supposed to be.

The changes in this pull request
- allow unforeseen date formats to be successfully converted.
- populate the disabilities table.

