### PR TITLE
separate data processing from conversion

### DIFF
--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -21,18 +21,16 @@ def enum_keys(dict_input):
     return enumed_dict
 
 
-def process_data(root):
+def convert_data(root):
     """
     Takes input data and processes it for validation.
 
     This function takes input XML data, and uses ElementTree, and the custom class
-    XMLtoCSV to process the data into tables for validation. Returning as a dict
-    or DataContainerWrapper object. Returns as dict for front-end purposes and object
-    for CLI interface.
+    XMLtoCSV to process the data into tables for validation.
 
-    :param XML filename: XML files passed from either the front end or the CLI.
-    :returns: Data files as object or dict of DataFrames for validation.
-    :rtype: Dictionary or DataContainerWrapper object.
+    :param XML root: root created by parsing the user's xml file.
+    :returns: dict of DataFrames - each representing a CIN table.
+    :rtype: Dictionary
     """
 
     # generate tables
@@ -51,6 +49,15 @@ def process_data(root):
         "Assessments": data_files.Assessments,
         "Disabilities": data_files.Disabilities,
     }
+    return cin_tables
+
+
+def process_data(cin_tables):
+    """
+    formats date columns
+    :param dict cin_tables: data to be converted
+    :return dict cin_tables_dict: original dataframes where date columns have been formatted.
+    """
 
     # format all date columns in tables
     cin_tables_dict = {

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -16,7 +16,7 @@ def generate_tables(cin_data):
     filetext = cin_data.read().decode("utf-8")
     root = ET.fromstring(filetext)
 
-    data_files = cin_class.process_data(root)
+    data_files = cin_class.convert_data(root)
 
     # make data json-serialisable
     json_data_files = {
@@ -41,12 +41,15 @@ def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     filetext = cin_data.read().decode("utf-8")
     root = ET.fromstring(filetext)
 
-    data_files = cin_class.process_data(root)
+    raw_data = cin_class.convert_data(root)
     json_data_files = {
         table_name: table_df.to_json(orient="records")
-        for table_name, table_df in data_files.items()
+        for table_name, table_df in raw_data.items()
     }
 
+    # format date columns
+    data_files = cin_class.process_data(raw_data)
+    # run validation
     validator = cin_class.CinValidationSession(
         data_files, ruleset, selected_rules=selected_rules
     )


### PR DESCRIPTION
This enabled unconverted datetimes to be sent to the frontend display without the need to convert back from datetime to string format.