### PR TITLE
8832 bugfix

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8832.py
+++ b/cin_validator/rules/cin2022_23/rule_8832.py
@@ -50,10 +50,16 @@ def validate(
     df_CINdetails.reset_index(inplace=True)
 
     # If a <CINdetails> module has <ReferralNFA> (N00112) = true or 1, then there should be no Child Protection module present
+
+    # Excluding rows with false or 0 <ReferralNFA> to fix bug where they were flagged as failing
+    df_CINdetails = df_CINdetails[
+        ~(df_CINdetails[ReferralNFA].str.lower() == "false")
+        | ~(df_CINdetails[ReferralNFA].astype(str) == "0")
+    ]
+
     df_CINdetails = df_CINdetails[
         (df_CINdetails[ReferralNFA].str.lower() == "true")
         | (df_CINdetails[ReferralNFA].astype(str) == "1")
-        | (df_CINdetails[ReferralNFA] == True)
     ]
 
     #  Merge tables to get corresponding CP plan group and reviews

--- a/cin_validator/rules/cin2022_23/rule_8832.py
+++ b/cin_validator/rules/cin2022_23/rule_8832.py
@@ -52,10 +52,11 @@ def validate(
     # If a <CINdetails> module has <ReferralNFA> (N00112) = true or 1, then there should be no Child Protection module present
 
     # Excluding rows with false or 0 <ReferralNFA> to fix bug where they were flagged as failing
-    # df_CINdetails = df_CINdetails[
-    #     ~(df_CINdetails[ReferralNFA].str.lower() == "false")
-    #     | ~(df_CINdetails[ReferralNFA].astype(str) == "0")
-    # ]
+    # TODO remove this step when proven to be redundant.
+    df_CINdetails = df_CINdetails[
+        ~(df_CINdetails[ReferralNFA].str.lower() == "false")
+        | ~(df_CINdetails[ReferralNFA].astype(str) == "0")
+    ]
 
     df_CINdetails = df_CINdetails[
         (df_CINdetails[ReferralNFA].str.lower() == "true")
@@ -126,6 +127,10 @@ def test_validate():
                 "LAchildID": "child4",  # ignored
                 "CINdetailsID": "CDID0",
             },
+            {
+                "LAchildID": "child5",  # ignored, ReferralNFA is neither "1" nor "true"
+                "CINdetailsID": "CDID0",
+            },
         ]
     )
     sample_cin = pd.DataFrame(
@@ -149,6 +154,11 @@ def test_validate():
                 "LAchildID": "child4",  # ignored, ReferralNFA is neither "1" nor "true"
                 "CINdetailsID": "CDID0",
                 "ReferralNFA": "false",
+            },
+            {
+                "LAchildID": "child5",  # ignored, ReferralNFA is neither "1" nor "true"
+                "CINdetailsID": "CDID0",
+                "ReferralNFA": 0,
             },
         ]
     )


### PR DESCRIPTION
8832 now excludes rows of ReferralNFA with value 0 or false, it should have done this anyway but they were getting caught in the merge and flagged as errors.

closes #317 