### PR TITLE
bugfix 8869

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8869.py
+++ b/cin_validator/rules/cin2022_23/rule_8869.py
@@ -85,7 +85,7 @@ def test_validate():
         "AAAA",  # id4, cinid4 fail. same assessment period has factor 21
         "AA",
         "21",
-        "14",
+        "14",  # ignored. not the same auth date as preceding.
         "15",
     ]
     # non-date placeholders can be used since this rule doesn't require date-object properties.

--- a/cin_validator/rules/cin2022_23/rule_8869.py
+++ b/cin_validator/rules/cin2022_23/rule_8869.py
@@ -15,6 +15,7 @@ from cin_validator.test_engine import run_rule
 Assessments = CINTable.Assessments
 LAchildID = Assessments.LAchildID
 AssessmentFactors = Assessments.AssessmentFactors
+CINdetailsID = Assessments.CINdetailsID
 AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 
 
@@ -50,13 +51,13 @@ def validate(
     # If <AssessmentFactors> (N00181) = “21”, this must be the only <AssessmentFactors> (N00181) present.
     df_orig = df.copy()
 
-    df = df[(df[AssessmentFactors] == "21") | (df[AssessmentFactors] == 21)]
+    df = df[(df[AssessmentFactors].astype(str) == "21")]
 
     #  Merge tables
     df = df.merge(
         df_orig,
         how="left",
-        on=["LAchildID", "AssessmentAuthorisationDate"],
+        on=[LAchildID, CINdetailsID, AssessmentAuthorisationDate],
         suffixes=["", "_orig"],
     )
 
@@ -73,19 +74,21 @@ def validate(
 def test_validate():
     # 0      #1      #2      #3     #4      #5      #6      #7
     ids = ["1", "1", "2", "3", "3", "4", "4", "5", "6", "6", "6"]
+    cinid = ["1", "1", "2", "3", "3", "4", "4", "5", "6", "6", "6"]
     assessmentfactors = [
         "21",
-        "AIND",
+        "AIND",  # id1, cinid1 fail. same assessment period has factor 21
         "NONE",
         pd.NA,
         "MOTH",
         "21",
-        "AAAA",
+        "AAAA",  # id4, cinid4 fail. same assessment period has factor 21
         "AA",
         "21",
         "14",
         "15",
     ]
+    # non-date placeholders can be used since this rule doesn't require date-object properties.
     assessmentauthorisationdate = [
         "1",
         "1",
@@ -103,6 +106,7 @@ def test_validate():
     fake_df = pd.DataFrame(
         {
             "LAchildID": ids,
+            "CINdetailsID": cinid,
             "AssessmentFactors": assessmentfactors,
             "AssessmentAuthorisationDate": assessmentauthorisationdate,
         }

--- a/cin_validator/rules/cin2022_23/rule_8869.py
+++ b/cin_validator/rules/cin2022_23/rule_8869.py
@@ -15,7 +15,7 @@ from cin_validator.test_engine import run_rule
 Assessments = CINTable.Assessments
 LAchildID = Assessments.LAchildID
 AssessmentFactors = Assessments.AssessmentFactors
-CINdetailsID = Assessments.CINdetailsID
+AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 
 
 # define characteristics of rule
@@ -50,11 +50,14 @@ def validate(
     # If <AssessmentFactors> (N00181) = “21”, this must be the only <AssessmentFactors> (N00181) present.
     df_orig = df.copy()
 
-    df = df[df[AssessmentFactors] == "21"]
+    df = df[(df[AssessmentFactors] == "21") | (df[AssessmentFactors] == 21)]
 
     #  Merge tables
     df = df.merge(
-        df_orig, how="left", on=["LAchildID", "CINdetailsID"], suffixes=["", "_orig"]
+        df_orig,
+        how="left",
+        on=["LAchildID", "AssessmentAuthorisationDate"],
+        suffixes=["", "_orig"],
     )
 
     # Values that aren't 21 are now errors (using guidelines from rule 8790)
@@ -69,15 +72,39 @@ def validate(
 
 def test_validate():
     # 0      #1      #2      #3     #4      #5      #6      #7
-    ids = ["1", "1", "2", "3", "3", "4", "4", "5"]
-    assessmentfactors = ["21", "AIND", "NONE", pd.NA, "MOTH", "21", "AAAA", "AA"]
-    cinid = ["1", "1", "2", "3", "3", "4", "4", "5"]
+    ids = ["1", "1", "2", "3", "3", "4", "4", "5", "6", "6", "6"]
+    assessmentfactors = [
+        "21",
+        "AIND",
+        "NONE",
+        pd.NA,
+        "MOTH",
+        "21",
+        "AAAA",
+        "AA",
+        "21",
+        "14",
+        "15",
+    ]
+    assessmentauthorisationdate = [
+        "1",
+        "1",
+        "2",
+        "3",
+        "3",
+        "4",
+        "4",
+        "5",
+        "2021-02-09",
+        "2020-12-15",
+        "2020-12-15",
+    ]
 
     fake_df = pd.DataFrame(
         {
             "LAchildID": ids,
             "AssessmentFactors": assessmentfactors,
-            "CINdetailsID": cinid,
+            "AssessmentAuthorisationDate": assessmentauthorisationdate,
         }
     )
 


### PR DESCRIPTION
closes #321 
8869 wrongly flagged rows where children had 21 as an assessment factor in a different assessment. This was because it checked assessment factors within one CINplan, where CIN plans can have multiple assessment periods. This was fixed by using AssessmentAuthorisationDate in the merge to separate out different assessment modules. It would be possible to merge on CINdetailsID and AssessmentAuthorisationDate but it's redundant.