### PR TITLE
8620 bugfix

### DIFF
--- a/Documentation/RULE_PATTERNS.MD
+++ b/Documentation/RULE_PATTERNS.MD
@@ -67,3 +67,8 @@ multiple tables
 
 # Notes
 Since the Asssessments table has no ID to distinguish groups from each other, the AssessmentAuthorisationDate is used as a differentiator.
+
+## Collection period
+The collection period across child census datasets tends to be from the 1st of April in one year to the 31st of March in the next year. 
+However, during preliminary testing, it was seen that the DfE tool includes the 31st of March of the previous year so this tool has adjusted it's calculations accordingly. 
+Now this tool calculates the collection start by substracting 1 year from the reference date in the uploaded data. As such the collection period starts and ends on the 31st of March from one year to the other. This decision is reversible.

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -63,9 +63,7 @@ def make_census_period(reference_date):
 
     # the collection start is the 1st of April of the previous year but dates from the day of the previous collection move to the next collection.
     # e.g. in the 22-23 collection, 2022-03-31 is an allowed date according to the test data.
-    collection_start = (
-        make_date(reference_date) - pd.DateOffset(years=1)
-    )
+    collection_start = make_date(reference_date) - pd.DateOffset(years=1)
 
     return collection_start, collection_end
 

--- a/cin_validator/utils.py
+++ b/cin_validator/utils.py
@@ -61,9 +61,10 @@ def make_census_period(reference_date):
     # the ReferenceDate value is always the collection_end date
     collection_end = make_date(reference_date)
 
-    # the collection start is the 1st of April of the previous year.
+    # the collection start is the 1st of April of the previous year but dates from the day of the previous collection move to the next collection.
+    # e.g. in the 22-23 collection, 2022-03-31 is an allowed date according to the test data.
     collection_start = (
-        make_date(reference_date) - pd.DateOffset(years=1) + pd.DateOffset(days=1)
+        make_date(reference_date) - pd.DateOffset(years=1)
     )
 
     return collection_start, collection_end


### PR DESCRIPTION
closes #315 

The previous calculation took the first day of the collection as the day after the previous years collection, but the test data, which has been accepted by the DFE as correct has lots of dates as the day of the last years collection end. As such, I've removed the - 1 year plus 1 day calculation and replaced it with just a minus 1 year calculation in make date, as this will solve the issue for any similar rules too.