### PR TITLE
bugfix 8890

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8890.py
+++ b/cin_validator/rules/cin2022_23/rule_8890.py
@@ -65,9 +65,13 @@ def validate(
     # b) the <S47ActualStartDate> (N00148) and the <ReferenceDate> (N00603) of any other <Section47> group
     #   that has a missing <DateOfInitialCPC> (N00110) and the <ICPCnotRequired> (N00111) flag is not true
 
-    #  Create dataframes which only have rows with CP plans, and which should have one plan per row.
-    df_47 = df_47[df_47[S47ActualStartDate].notna()]
-    df_47_2 = df_47_2[df_47_2[S47ActualStartDate].notna()]
+    #  Create dataframes which only have rows with s47 modules, and which don't have ICPCnotrequired as true should have one plan per row.
+    df_47 = df_47[
+        (df_47[S47ActualStartDate].notna()) & (df_47[ICPCnotRequired] != "true")
+    ]
+    df_47_2 = df_47_2[
+        (df_47_2[S47ActualStartDate].notna()) & (df_47_2[ICPCnotRequired] != "true")
+    ]
 
     #  Merge tables to test for overlaps
     df_merged = df_47.merge(

--- a/cin_validator/rules/cin2022_23/rule_8890.py
+++ b/cin_validator/rules/cin2022_23/rule_8890.py
@@ -212,6 +212,21 @@ def test_validate():
                 "DateOfInitialCPC": pd.NA,
                 "ICPCnotRequired": "1",
             },
+            # child5
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID0",
+                "S47ActualStartDate": "26/05/2000",  # 4 Pass: not between "26/08/2000" and "26/10/2000"
+                "DateOfInitialCPC": "26/10/2001",
+                "ICPCnotRequired": "true",
+            },
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID0",
+                "S47ActualStartDate": "26/08/2000",  # 5 Fail: between "26/05/2000" and "26/10/2001"
+                "DateOfInitialCPC": "26/10/2000",
+                "ICPCnotRequired": "1",
+            },
         ]
     )
 

--- a/cin_validator/rules/cin2022_23/rule_8890.py
+++ b/cin_validator/rules/cin2022_23/rule_8890.py
@@ -66,12 +66,8 @@ def validate(
     #   that has a missing <DateOfInitialCPC> (N00110) and the <ICPCnotRequired> (N00111) flag is not true
 
     #  Create dataframes which only have rows with s47 modules, and which don't have ICPCnotrequired as true should have one plan per row.
-    df_47 = df_47[
-        (df_47[S47ActualStartDate].notna())
-    ]
-    df_47_2 = df_47_2[
-        (df_47_2[S47ActualStartDate].notna())
-    ]
+    df_47 = df_47[(df_47[S47ActualStartDate].notna())]
+    df_47_2 = df_47_2[(df_47_2[S47ActualStartDate].notna())]
 
     #  Merge tables to test for overlaps
     df_merged = df_47.merge(


### PR DESCRIPTION
closes #322 

Given that it should flag:
 b) the <S47ActualStartDate> (N00148) and the <ReferenceDate> (N00603) of any other <Section47> group  that has a missing <DateOfInitialCPC> (N00110) and the <ICPCnotRequired> (N00111) flag is not true,
this rule should not flag as concurrent s47 modules where ICPCnotRequired is true, which it is, which is causing rows to be wrongly flagged, eg:

```
                <Section47>
                    <S47ActualStartDate>xxx</S47ActualStartDate>
                    <ICPCnotRequired>true</ICPCnotRequired>
                </Section47>
                <Section47>
                    <S47ActualStartDate>xxx</S47ActualStartDate>
                    <ICPCnotRequired>true</ICPCnotRequired>
                </Section47>
```

The changes mean that modules where ICPCnotrequired == true are not picked up.