### PR TITLE
Bugfix 8863

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-    print(df_merged['LAchildID'])
+    print(df_merged["LAchildID"])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -199,13 +199,13 @@ def test_validate():
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentActualStartDate": "01/03/2000",
                 "AssessmentAuthorisationDate": "01/04/2000",
-            },  
+            },
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentActualStartDate": "01/09/2000",
                 "AssessmentAuthorisationDate": "01/10/2000",
             },
         ]

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-    
+
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -23,7 +23,7 @@ ReferenceDate = Header.ReferenceDate
 @rule_definition(
     code=8863,
     module=CINTable.Assessments,
-    message="An Assessment is shown as starting when there is another Assessment ongoing",
+    message="An Assessment is shown as starting when there is another Assessment ongoing.",
     affected_fields=[AssessmentActualStartDate, AssessmentAuthorisationDate],
 )
 def validate(
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-
+    print(df_merged['LAchildID'])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -196,6 +196,18 @@ def test_validate():
                 "AssessmentActualStartDate": "26/09/2000",  # 7 Pass: not between "26/10/2000" and "31/03/2001"
                 "AssessmentAuthorisationDate": pd.NA,
             },
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentAuthorisationDate": "01/04/2000",
+            },  
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentAuthorisationDate": "01/10/2000",
+            },
         ]
     )
 
@@ -282,5 +294,5 @@ def test_validate():
     assert result.definition.code == 8863
     assert (
         result.definition.message
-        == "An Assessment is shown as starting when there is another Assessment ongoing"
+        == "An Assessment is shown as starting when there is another Assessment ongoing."
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-    print(df_merged["LAchildID"])
+    
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -88,16 +88,16 @@ def validate(
 
     # Determine whether assessment overlaps with another assessment
     ass_started_after_start = (
-        df_merged["AssessmentActualStartDate_ass"]
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts later than 2 starts
         >= df_merged["AssessmentActualStartDate_ass2"]
     )
     ass_started_before_end = (
-        df_merged["AssessmentActualStartDate_ass"]
-        <= df_merged["AssessmentAuthorisationDate_ass"]
-    ) & df_merged["AssessmentAuthorisationDate_ass"].notna()
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts earlier than 2 finishes
+        <= df_merged["AssessmentAuthorisationDate_ass2"]
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].notna()
     ass_started_before_refdate = (
         df_merged["AssessmentActualStartDate_ass"] <= reference_date
-    ) & df_merged["AssessmentAuthorisationDate_ass"].isna()
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].isna()
 
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)


### PR DESCRIPTION
closes #319 

Within one <CINdetails> group, where present each <AssessmentActualStartDate> (N00159) must not fall on or between:
    a) the <AssessmentActualStartDate> (N00159) and <AssessmentAuthorisation Date (N00160) of any other <Assessments> 
        group that has an <AssessmentAuthorisationDate> (N00160)
    OR
    b) the <AssessmentActualStartDate> (N00159) and the <ReferenceDate> (N00603) where the 
        <AssessmentAuthorisationDate> (N00160) is missing

This is incorrectly failing the following data:

```
                <Assessments>
                    <AssessmentActualStartDate>2021-09-XX</AssessmentActualStartDate>
                    <AssessmentAuthorisationDate>2021-10-XX</AssessmentAuthorisationDate>
                </Assessments>
                <Assessments>
                    <AssessmentActualStartDate>2021-03-XX</AssessmentActualStartDate>
                    <AssessmentAuthorisationDate>2021-04-XX</AssessmentAuthorisationDate>
                </Assessments>
```

Where both have assessment authorisation dates, and do not occur concurrently.

I was able to recreate the bug in the cod eby using the following in the sample df for 8863:
```

            {
                "LAchildID": "child5",
                "CINdetailsID": "cinID1",
                "AssessmentActualStartDate": "01/03/2000",  
                "AssessmentAuthorisationDate": "01/04/2000",
            },  
            {
                "LAchildID": "child5",
                "CINdetailsID": "cinID1",
                "AssessmentActualStartDate": "01/09/2000", 
                "AssessmentAuthorisationDate": "01/10/2000",
            },
```

On if we call the first Ass. period 1, and the second 2, and s for start, e for end, and r for reference date, the code was originally checking if 1s was after  2s and (correct) and if 1s was before 1e or the reference date (wrong). I've fixed it so it now checks if 1s is between 2s and 2e/r, which is right. I've illustrated the change with an image which may or may not make sense: 
![image](https://user-images.githubusercontent.com/108789355/218787717-3721bdd9-6543-45c5-912e-a87575c6c2ed.png)
