### PR TITLE
Bugfix 8839

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8839.py
+++ b/cin_validator/rules/cin2022_23/rule_8839.py
@@ -43,8 +43,10 @@ def validate(
     # DF_CHECK: APPLY GROUPBYs IN A SEPARATE DATAFRAME SO THAT OTHER COLUMNS ARE NOT LOST OR CORRUPTED. THEN, MAP THE RESULTS TO THE INITIAL DATAFRAME.
     df_check = df.copy()
     # get all the locations where ICPCnotRequired is null or not true (1)
+    # The rule originally asks for true, not 1, but an analyst coded it for 1, so their LA may use 1 and 0 instead, as such, it now check for either.
     df_check = df_check[
-        df_check[ICPCnotRequired].isna() | (df_check[ICPCnotRequired] != 1)
+        df_check[ICPCnotRequired].isna()
+        | (~df_check[ICPCnotRequired].isin([1, "true"]))
     ]
     # get all the locations where DateOfInitialCPC is null
     df_check = df_check[df_check[DateOfInitialCPC].isna()]
@@ -131,13 +133,19 @@ def test_validate():
                 LAchildID: "child3",
                 CINdetailsID: "cinID3",
                 DateOfInitialCPC: pd.NA,  # 6 nan but also ICPC not required
-                ICPCnotRequired: 1,
+                ICPCnotRequired: "true",
             },
             {  # pass
                 LAchildID: "child3",
                 CINdetailsID: "cinID3",
                 DateOfInitialCPC: pd.NA,  # 7 not more than one nan authorisation date in group
                 ICPCnotRequired: pd.NA,
+            },
+            {  # pass
+                LAchildID: "child3",
+                CINdetailsID: "cinID3",
+                DateOfInitialCPC: pd.NA,  # 6 nan but also ICPC not required
+                ICPCnotRequired: 1,
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-    print(df_merged['LAchildID'])
+    print(df_merged["LAchildID"])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -199,13 +199,13 @@ def test_validate():
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentActualStartDate": "01/03/2000",
                 "AssessmentAuthorisationDate": "01/04/2000",
-            },  
+            },
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentActualStartDate": "01/09/2000",
                 "AssessmentAuthorisationDate": "01/10/2000",
             },
         ]

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -23,7 +23,7 @@ ReferenceDate = Header.ReferenceDate
 @rule_definition(
     code=8863,
     module=CINTable.Assessments,
-    message="An Assessment is shown as starting when there is another Assessment ongoing",
+    message="An Assessment is shown as starting when there is another Assessment ongoing.",
     affected_fields=[AssessmentActualStartDate, AssessmentAuthorisationDate],
 )
 def validate(
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-
+    print(df_merged['LAchildID'])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -196,6 +196,18 @@ def test_validate():
                 "AssessmentActualStartDate": "26/09/2000",  # 7 Pass: not between "26/10/2000" and "31/03/2001"
                 "AssessmentAuthorisationDate": pd.NA,
             },
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentAuthorisationDate": "01/04/2000",
+            },  
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentAuthorisationDate": "01/10/2000",
+            },
         ]
     )
 
@@ -282,5 +294,5 @@ def test_validate():
     assert result.definition.code == 8863
     assert (
         result.definition.message
-        == "An Assessment is shown as starting when there is another Assessment ongoing"
+        == "An Assessment is shown as starting when there is another Assessment ongoing."
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -88,16 +88,16 @@ def validate(
 
     # Determine whether assessment overlaps with another assessment
     ass_started_after_start = (
-        df_merged["AssessmentActualStartDate_ass"]
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts later than 2 starts
         >= df_merged["AssessmentActualStartDate_ass2"]
     )
     ass_started_before_end = (
-        df_merged["AssessmentActualStartDate_ass"]
-        <= df_merged["AssessmentAuthorisationDate_ass"]
-    ) & df_merged["AssessmentAuthorisationDate_ass"].notna()
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts earlier than 2 finishes
+        <= df_merged["AssessmentAuthorisationDate_ass2"]
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].notna()
     ass_started_before_refdate = (
         df_merged["AssessmentActualStartDate_ass"] <= reference_date
-    ) & df_merged["AssessmentAuthorisationDate_ass"].isna()
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].isna()
 
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)


### PR DESCRIPTION
closes #318 

Within one <CINdetails> group, there must be only:
one <Section47> group that has no <DateOfInitialCPC> (N00110) recorded, OR 
<Section47> group that has a missing <DateOfInitialCPC> (N00110) and the <ICPCnotRequired> (N00111) flag is not true

The rule is currently failing data as follows: 
```
               <Section47>
                    <S47ActualStartDate>XXXX</S47ActualStartDate>
                    <ICPCnotRequired>true</ICPCnotRequired>
                </Section47>
                <Section47>
                    <S47ActualStartDate>XXXX</S47ActualStartDate>
                    <ICPCnotRequired>true</ICPCnotRequired>
                </Section47>
```

Meaning it's failing data where the ICPCnotRequired is true.

To fix: fix ICPCnotRequired == true check

The rule technically asks for true, not 1, but an analyst coded it as 1, so I've allowed for both in case some LAs use 1/0 instead of true/false