### PR TITLE
Bugfix 8820

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_8820.py
+++ b/cin_validator/rules/cin2022_23/rule_8820.py
@@ -87,23 +87,22 @@ def validate(
 
     # Determine overlaps
     cin_started_after_start = (
-        df_merged["CINreferralDate_cin"] >= df_merged["CINreferralDate_cin2"]
+        df_merged["CINreferralDate_cin"] > df_merged["CINreferralDate_cin2"]
     )
     cin_started_before_end = (
-        df_merged["CINreferralDate_cin"] <= df_merged["CINclosureDate_cin2"]
+        df_merged["CINreferralDate_cin"] < df_merged["CINclosureDate_cin2"]
     ) & df_merged["CINclosureDate_cin2"].notna()
 
-    falsezero = ["False", "0"]
     cin_started_before_refdate = (
-        (df_merged["CINreferralDate_cin"] <= reference_date)
+        (df_merged["CINreferralDate_cin"] < reference_date)
         & df_merged["CINclosureDate_cin2"].isna()
-        & df_merged["ReferralNFA_cin2"].isin(falsezero)
+        & df_merged["ReferralNFA_cin2"].isin(["false", "0", 0, "False"])
     )
 
     df_merged = df_merged[
         cin_started_after_start & (cin_started_before_end | cin_started_before_refdate)
     ].reset_index()
-
+    print(df_merged)
     # create an identifier for each error instance.
     # In this case, the rule is checked for each CPPstartDate, in each CPplanDates group (differentiated by CP dates), in each child (differentiated by LAchildID)
     df_merged["ERROR_ID"] = tuple(
@@ -165,14 +164,14 @@ def test_validate():
             # child2
             {
                 "LAchildID": "child2",
-                "CINreferralDate": "26/05/2000",  # 2 alone in cin group: not compared
+                "CINreferralDate": "26/05/2000",  # 2 pass, not between
                 "CINclosureDate": "25/10/2000",
                 "CINdetailsID": "cinID2",
                 "ReferralNFA": "true",
             },
             {
                 "LAchildID": "child2",
-                "CINreferralDate": "26/10/2000",  # 3 alone in cin group: not compared
+                "CINreferralDate": "26/10/2000",  # 3 pass, not between
                 "CINclosureDate": "26/12/2000",
                 "CINdetailsID": "cinID22",
                 "ReferralNFA": "true",
@@ -204,7 +203,23 @@ def test_validate():
                 "LAchildID": "child4",
                 "CINreferralDate": "26/09/2000",  # 7 Pass: not between "26/10/2000" and "31/03/2001"
                 "CINclosureDate": pd.NA,
+                "CINdetailsID": "cinID42",
                 "ReferralNFA": "true",
+            },
+            # child 5
+            {
+                "LAchildID": "child5",
+                "CINreferralDate": "08/07/2000",
+                "CINclosureDate": "23/08/2000",
+                "CINdetailsID": "cinID4",
+                "ReferralNFA": "false",
+            },
+            {
+                "LAchildID": "child5",
+                "CINreferralDate": "05/05/2000",
+                "CINclosureDate": "08/07/2000",
+                "CINdetailsID": "cinID5",
+                "ReferralNFA": "false",
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_8820.py
+++ b/cin_validator/rules/cin2022_23/rule_8820.py
@@ -96,13 +96,13 @@ def validate(
     cin_started_before_refdate = (
         (df_merged["CINreferralDate_cin"] < reference_date)
         & df_merged["CINclosureDate_cin2"].isna()
-        & df_merged["ReferralNFA_cin2"].isin(["false", "0", 0, "False"])
+        & df_merged["ReferralNFA_cin2"].str.lower().isin(["false", "0"])
     )
 
     df_merged = df_merged[
         cin_started_after_start & (cin_started_before_end | cin_started_before_refdate)
     ].reset_index()
-    print(df_merged)
+
     # create an identifier for each error instance.
     # In this case, the rule is checked for each CPPstartDate, in each CPplanDates group (differentiated by CP dates), in each child (differentiated by LAchildID)
     df_merged["ERROR_ID"] = tuple(

--- a/cin_validator/rules/cin2022_23/rule_8839.py
+++ b/cin_validator/rules/cin2022_23/rule_8839.py
@@ -43,8 +43,10 @@ def validate(
     # DF_CHECK: APPLY GROUPBYs IN A SEPARATE DATAFRAME SO THAT OTHER COLUMNS ARE NOT LOST OR CORRUPTED. THEN, MAP THE RESULTS TO THE INITIAL DATAFRAME.
     df_check = df.copy()
     # get all the locations where ICPCnotRequired is null or not true (1)
+    # The rule originally asks for true, not 1, but an analyst coded it for 1, so their LA may use 1 and 0 instead, as such, it now check for either.
     df_check = df_check[
-        df_check[ICPCnotRequired].isna() | (df_check[ICPCnotRequired] != 1)
+        df_check[ICPCnotRequired].isna()
+        | (~df_check[ICPCnotRequired].isin([1, "true"]))
     ]
     # get all the locations where DateOfInitialCPC is null
     df_check = df_check[df_check[DateOfInitialCPC].isna()]
@@ -131,13 +133,19 @@ def test_validate():
                 LAchildID: "child3",
                 CINdetailsID: "cinID3",
                 DateOfInitialCPC: pd.NA,  # 6 nan but also ICPC not required
-                ICPCnotRequired: 1,
+                ICPCnotRequired: "true",
             },
             {  # pass
                 LAchildID: "child3",
                 CINdetailsID: "cinID3",
                 DateOfInitialCPC: pd.NA,  # 7 not more than one nan authorisation date in group
                 ICPCnotRequired: pd.NA,
+            },
+            {  # pass
+                LAchildID: "child3",
+                CINdetailsID: "cinID3",
+                DateOfInitialCPC: pd.NA,  # 6 nan but also ICPC not required
+                ICPCnotRequired: 1,
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-    print(df_merged['LAchildID'])
+    print(df_merged["LAchildID"])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -199,13 +199,13 @@ def test_validate():
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentActualStartDate": "01/03/2000",
                 "AssessmentAuthorisationDate": "01/04/2000",
-            },  
+            },
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentActualStartDate": "01/09/2000",
                 "AssessmentAuthorisationDate": "01/10/2000",
             },
         ]

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -23,7 +23,7 @@ ReferenceDate = Header.ReferenceDate
 @rule_definition(
     code=8863,
     module=CINTable.Assessments,
-    message="An Assessment is shown as starting when there is another Assessment ongoing",
+    message="An Assessment is shown as starting when there is another Assessment ongoing.",
     affected_fields=[AssessmentActualStartDate, AssessmentAuthorisationDate],
 )
 def validate(
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-
+    print(df_merged['LAchildID'])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -196,6 +196,18 @@ def test_validate():
                 "AssessmentActualStartDate": "26/09/2000",  # 7 Pass: not between "26/10/2000" and "31/03/2001"
                 "AssessmentAuthorisationDate": pd.NA,
             },
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentAuthorisationDate": "01/04/2000",
+            },  
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentAuthorisationDate": "01/10/2000",
+            },
         ]
     )
 
@@ -282,5 +294,5 @@ def test_validate():
     assert result.definition.code == 8863
     assert (
         result.definition.message
-        == "An Assessment is shown as starting when there is another Assessment ongoing"
+        == "An Assessment is shown as starting when there is another Assessment ongoing."
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -88,16 +88,16 @@ def validate(
 
     # Determine whether assessment overlaps with another assessment
     ass_started_after_start = (
-        df_merged["AssessmentActualStartDate_ass"]
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts later than 2 starts
         >= df_merged["AssessmentActualStartDate_ass2"]
     )
     ass_started_before_end = (
-        df_merged["AssessmentActualStartDate_ass"]
-        <= df_merged["AssessmentAuthorisationDate_ass"]
-    ) & df_merged["AssessmentAuthorisationDate_ass"].notna()
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts earlier than 2 finishes
+        <= df_merged["AssessmentAuthorisationDate_ass2"]
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].notna()
     ass_started_before_refdate = (
         df_merged["AssessmentActualStartDate_ass"] <= reference_date
-    ) & df_merged["AssessmentAuthorisationDate_ass"].isna()
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].isna()
 
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)


### PR DESCRIPTION
closes #316 

```
f more than one <CINdetails> module is present for the same child, then for each module the
 <CINreferralDate> (N00100) must not fall;
a) between the <CINreferralDate> (N00100) and the <CINclosureDate> (N00102) if present; and
 b) between the <CINreferralDate> (N00100) and the <ReferenceDate> (N00603)
 if the <CINclosureDate> is not present and <ReferralNFA> (N00112) = false or 0
```

The rule currently fails:
```
            <CINdetails>
                <CINreferralDate>2021-07-AA</CINreferralDate>
                <CINclosureDate>2021-08-XX</CINclosureDate>
                <ReferralNFA>false</ReferralNFA>
            </CINdetails>
            <CINdetails>
                <CINreferralDate>2021-05-XX</CINreferralDate>
                <CINclosureDate>2021-07-AA</CINclosureDate>
                <ReferralNFA>false</ReferralNFA>
            </CINdetails>
```

Where  the referral date of the first block is the same as the closure date of the second. To fix the rule, allow the referral and closure of blocks to be the same.

The fix removes the = signs from the >=/<= equality checks as these meant you couldnt finish a plan one day and starta  new one the same day, which is allowed.