### PR TITLE
Bugfix 2885

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_2885.py
+++ b/cin_validator/rules/cin2022_23/rule_2885.py
@@ -99,8 +99,18 @@ def validate(
         suffixes=["_47", "_cin"],
         # the suffixes apply to all the columns not "merged on". That is, DateOfInitialCPC
     )
-    print(merged_df[['LAchildID', "DateOfInitialCPC_47", "DateOfInitialCPC_cin", "CPPstartDate", "CINdetailsID"]])
-    
+    print(
+        merged_df[
+            [
+                "LAchildID",
+                "DateOfInitialCPC_47",
+                "DateOfInitialCPC_cin",
+                "CPPstartDate",
+                "CINdetailsID",
+            ]
+        ]
+    )
+
     # check that the the dates being compared existed in the same CIN event period and belong to the same child.
     condition = (merged_df[CPPstartDate] != merged_df["DateOfInitialCPC_47"]) & (
         merged_df[CPPstartDate] != merged_df["DateOfInitialCPC_cin"]
@@ -112,7 +122,17 @@ def validate(
 
     # get all the data that fits the failing condition.
     merged_df = merged_df[condition].reset_index()
-    print(merged_df[['LAchildID', "DateOfInitialCPC_47", "DateOfInitialCPC_cin", "CPPstartDate", "CINdetailsID"]])
+    print(
+        merged_df[
+            [
+                "LAchildID",
+                "DateOfInitialCPC_47",
+                "DateOfInitialCPC_cin",
+                "CPPstartDate",
+                "CINdetailsID",
+            ]
+        ]
+    )
     # create an identifier for each error instance.
     # In this case, the rule is checked for each CPPstartDate, in each CINplanDates group (differentiated by CINdetailsID), in each child (differentiated by LAchildID)
     # So, a combination of LAchildID, CINdetailsID and CPPstartDate identifies and error instance.

--- a/cin_validator/rules/cin2022_23/rule_2885.py
+++ b/cin_validator/rules/cin2022_23/rule_2885.py
@@ -30,7 +30,7 @@ ReferenceDate = Header.ReferenceDate
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.ChildProtectionPlans,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
-    message="Child protection plan shown as starting a different day to the initial child protection conference",
+    message="Child protection plan shown as starting a different day to the initial child protection conference.",
     # The column names tend to be the words within the < > signs in the github issue description.
     affected_fields=[
         CPPstartDate,
@@ -99,6 +99,8 @@ def validate(
         suffixes=["_47", "_cin"],
         # the suffixes apply to all the columns not "merged on". That is, DateOfInitialCPC
     )
+    print(merged_df[['LAchildID', "DateOfInitialCPC_47", "DateOfInitialCPC_cin", "CPPstartDate", "CINdetailsID"]])
+    
     # check that the the dates being compared existed in the same CIN event period and belong to the same child.
     condition = (merged_df[CPPstartDate] != merged_df["DateOfInitialCPC_47"]) & (
         merged_df[CPPstartDate] != merged_df["DateOfInitialCPC_cin"]
@@ -110,7 +112,7 @@ def validate(
 
     # get all the data that fits the failing condition.
     merged_df = merged_df[condition].reset_index()
-
+    print(merged_df[['LAchildID', "DateOfInitialCPC_47", "DateOfInitialCPC_cin", "CPPstartDate", "CINdetailsID"]])
     # create an identifier for each error instance.
     # In this case, the rule is checked for each CPPstartDate, in each CINplanDates group (differentiated by CINdetailsID), in each child (differentiated by LAchildID)
     # So, a combination of LAchildID, CINdetailsID and CPPstartDate identifies and error instance.
@@ -158,7 +160,7 @@ def test_validate():
         [
             {  # same as Section47 date, different from cin date
                 "LAchildID": "child1",
-                "CPPstartDate": "26/05/2000",  # 0 pass
+                "CPPstartDate": "26/05/2021",  # 0 pass
                 "CINdetailsID": "cinID1",
             },
             {  # would've failed but ignored. Not in period of census
@@ -168,12 +170,12 @@ def test_validate():
             },
             {  # same as cin_date, different from section47
                 "LAchildID": "child2",
-                "CPPstartDate": "26/05/2000",  # 2 pass [Should fail if other condition is used and section47 is present]
+                "CPPstartDate": "26/05/2021",  # 2 pass [Should fail if other condition is used and section47 is present]
                 "CINdetailsID": "cinID1",
             },
             {  # different from both dates
                 "LAchildID": "child3",
-                "CPPstartDate": "26/05/2000",  # 3 fail
+                "CPPstartDate": "26/05/2021",  # 3 fail
                 "CINdetailsID": "cinID1",
             },
             {  # absent
@@ -183,13 +185,23 @@ def test_validate():
             },
             {  # fail
                 "LAchildID": "child3",
-                "CPPstartDate": "07/02/2001",  # 5 fail. Different from both cin_dates in its cindetails group
+                "CPPstartDate": "07/02/2022",  # 5 fail. Different from both cin_dates in its cindetails group
                 "CINdetailsID": "cinID3",
             },
             {  # section47 date is absent, same as cin date.
                 # If grouping is not done well, this date could cause (LAchildID3, CINdetailsID3) above to pass.
                 "LAchildID": "child3",
-                "CPPstartDate": "14/03/2001",  # 6 pass [Should fail if other condition is used]
+                "CPPstartDate": "14/03/2022",  # 6 pass [Should fail if other condition is used]
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child5",
+                "CPPstartDate": "19/07/2021",
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child6",
+                "CPPstartDate": "19/07/2021",
                 "CINdetailsID": "cinID4",
             },
         ]
@@ -198,36 +210,51 @@ def test_validate():
         [
             {  # 0 pass
                 "LAchildID": "child1",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID1",
             },
             {  # 1 ignored
                 "LAchildID": "child1",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID2",
             },
             {  # 2 pass
                 "LAchildID": "child2",
-                "DateOfInitialCPC": "30/05/2000",
+                "DateOfInitialCPC": "30/05/2021",
                 "CINdetailsID": "cinID1",
             },
             {  # 3 fail
                 "LAchildID": "child3",
-                "DateOfInitialCPC": "27/05/2000",
+                "DateOfInitialCPC": "27/05/2021",
                 "CINdetailsID": "cinID1",
             },
             {  # 4 absent, ignored
                 "LAchildID": "child3",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID2",
             },
             {  # 5 fail
                 "LAchildID": "child3",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID3",
             },
             {  # 6 pass
                 "LAchildID": "child3",
+                "DateOfInitialCPC": pd.NA,
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child5",
+                "DateOfInitialCPC": "19/07/2021",
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child5",
+                "DateOfInitialCPC": pd.NA,
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child6",
                 "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID4",
             },
@@ -237,27 +264,27 @@ def test_validate():
         [
             {  # 0 pass
                 "LAchildID": "child1",
-                "DateOfInitialCPC": "26/10/1999",
+                "DateOfInitialCPC": "26/10/2020",
                 "CINdetailsID": "cinID1",
             },
             {  # 1 ignore
                 "LAchildID": "child1",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID2",
             },
             {  # 2 pass
                 "LAchildID": "child2",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID1",
             },
             {  # 3 fail
                 "LAchildID": "child3",
-                "DateOfInitialCPC": "28/05/2000",
+                "DateOfInitialCPC": "28/05/2021",
                 "CINdetailsID": "cinID1",
             },
             {  # 4 ignore
                 "LAchildID": "child3",
-                "DateOfInitialCPC": "26/05/2000",
+                "DateOfInitialCPC": "26/05/2021",
                 "CINdetailsID": "cinID2",
             },
             {  # 5 fail
@@ -267,12 +294,28 @@ def test_validate():
             },
             {  # 6 pass
                 "LAchildID": "child3",
-                "DateOfInitialCPC": "14/03/2001",
+                "DateOfInitialCPC": "14/03/2022",
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child5",
+                "DateOfInitialCPC": pd.NA,
+                "CINdetailsID": "cinID4",
+            },
+            {
+                "LAchildID": "child6",
+                "DateOfInitialCPC": pd.NA,
                 "CINdetailsID": "cinID4",
             },
         ]
     )
     # if rule requires columns containing date values, convert those columns to datetime objects first. Do it here in the test_validate function, not above.
+    sample_header = pd.DataFrame(
+        [{ReferenceDate: "31/03/2022"}]  # the census start date here will be 01/04/2021
+    )
+    sample_header[ReferenceDate] = pd.to_datetime(
+        sample_header[ReferenceDate], format="%d/%m/%Y", errors="coerce"
+    )
     sample_cpp[CPPstartDate] = pd.to_datetime(
         sample_cpp[CPPstartDate], format="%d/%m/%Y", errors="coerce"
     )
@@ -281,9 +324,6 @@ def test_validate():
     )
     sample_cin_details["DateOfInitialCPC"] = pd.to_datetime(
         sample_cin_details["DateOfInitialCPC"], format="%d/%m/%Y", errors="coerce"
-    )
-    sample_header = pd.DataFrame(
-        [{ReferenceDate: "31/03/2001"}]  # the census start date here will be 01/04/2000
     )
 
     # Run the rule function, passing in our sample data.
@@ -332,7 +372,7 @@ def test_validate():
                     "child3",  # ChildID
                     "cinID1",  # CINdetailsID
                     # corresponding CPPstartDate
-                    pd.to_datetime("26/05/2000", format="%d/%m/%Y", errors="coerce"),
+                    pd.to_datetime("26/05/2021", format="%d/%m/%Y", errors="coerce"),
                 ),
                 "ROW_ID": [3],
             },
@@ -340,9 +380,17 @@ def test_validate():
                 "ERROR_ID": (
                     "child3",
                     "cinID3",
-                    pd.to_datetime("07/02/2001", format="%d/%m/%Y", errors="coerce"),
+                    pd.to_datetime("07/02/2022", format="%d/%m/%Y", errors="coerce"),
                 ),
                 "ROW_ID": [5],
+            },
+            {
+                "ERROR_ID": (
+                    "child6",
+                    "cinID4",
+                    pd.to_datetime("19/07/2021", format="%d/%m/%Y", errors="coerce"),
+                ),
+                "ROW_ID": [8],
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_2885.py
+++ b/cin_validator/rules/cin2022_23/rule_2885.py
@@ -99,17 +99,6 @@ def validate(
         suffixes=["_47", "_cin"],
         # the suffixes apply to all the columns not "merged on". That is, DateOfInitialCPC
     )
-    # print(
-    #     merged_df[
-    #         [
-    #             "LAchildID",
-    #             "DateOfInitialCPC_47",
-    #             "DateOfInitialCPC_cin",
-    #             "CPPstartDate",
-    #             "CINdetailsID",
-    #         ]
-    #     ]
-    # )
 
     #  Filter out rows where there are multiple s47 modules, some with DateOfInitialCPC and some without
     no_dates = merged_df[

--- a/cin_validator/rules/cin2022_23/rule_8820.py
+++ b/cin_validator/rules/cin2022_23/rule_8820.py
@@ -87,23 +87,22 @@ def validate(
 
     # Determine overlaps
     cin_started_after_start = (
-        df_merged["CINreferralDate_cin"] >= df_merged["CINreferralDate_cin2"]
+        df_merged["CINreferralDate_cin"] > df_merged["CINreferralDate_cin2"]
     )
     cin_started_before_end = (
-        df_merged["CINreferralDate_cin"] <= df_merged["CINclosureDate_cin2"]
+        df_merged["CINreferralDate_cin"] < df_merged["CINclosureDate_cin2"]
     ) & df_merged["CINclosureDate_cin2"].notna()
 
-    falsezero = ["False", "0"]
     cin_started_before_refdate = (
-        (df_merged["CINreferralDate_cin"] <= reference_date)
+        (df_merged["CINreferralDate_cin"] < reference_date)
         & df_merged["CINclosureDate_cin2"].isna()
-        & df_merged["ReferralNFA_cin2"].isin(falsezero)
+        & df_merged["ReferralNFA_cin2"].isin(["false", "0", 0, "False"])
     )
 
     df_merged = df_merged[
         cin_started_after_start & (cin_started_before_end | cin_started_before_refdate)
     ].reset_index()
-
+    print(df_merged)
     # create an identifier for each error instance.
     # In this case, the rule is checked for each CPPstartDate, in each CPplanDates group (differentiated by CP dates), in each child (differentiated by LAchildID)
     df_merged["ERROR_ID"] = tuple(
@@ -165,14 +164,14 @@ def test_validate():
             # child2
             {
                 "LAchildID": "child2",
-                "CINreferralDate": "26/05/2000",  # 2 alone in cin group: not compared
+                "CINreferralDate": "26/05/2000",  # 2 pass, not between
                 "CINclosureDate": "25/10/2000",
                 "CINdetailsID": "cinID2",
                 "ReferralNFA": "true",
             },
             {
                 "LAchildID": "child2",
-                "CINreferralDate": "26/10/2000",  # 3 alone in cin group: not compared
+                "CINreferralDate": "26/10/2000",  # 3 pass, not between
                 "CINclosureDate": "26/12/2000",
                 "CINdetailsID": "cinID22",
                 "ReferralNFA": "true",
@@ -204,7 +203,23 @@ def test_validate():
                 "LAchildID": "child4",
                 "CINreferralDate": "26/09/2000",  # 7 Pass: not between "26/10/2000" and "31/03/2001"
                 "CINclosureDate": pd.NA,
+                "CINdetailsID": "cinID42",
                 "ReferralNFA": "true",
+            },
+            # child 5
+            {
+                "LAchildID": "child5",
+                "CINreferralDate": "08/07/2000",
+                "CINclosureDate": "23/08/2000",
+                "CINdetailsID": "cinID4",
+                "ReferralNFA": "false",
+            },
+            {
+                "LAchildID": "child5",
+                "CINreferralDate": "05/05/2000",
+                "CINclosureDate": "08/07/2000",
+                "CINdetailsID": "cinID5",
+                "ReferralNFA": "false",
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_8839.py
+++ b/cin_validator/rules/cin2022_23/rule_8839.py
@@ -43,8 +43,10 @@ def validate(
     # DF_CHECK: APPLY GROUPBYs IN A SEPARATE DATAFRAME SO THAT OTHER COLUMNS ARE NOT LOST OR CORRUPTED. THEN, MAP THE RESULTS TO THE INITIAL DATAFRAME.
     df_check = df.copy()
     # get all the locations where ICPCnotRequired is null or not true (1)
+    # The rule originally asks for true, not 1, but an analyst coded it for 1, so their LA may use 1 and 0 instead, as such, it now check for either.
     df_check = df_check[
-        df_check[ICPCnotRequired].isna() | (df_check[ICPCnotRequired] != 1)
+        df_check[ICPCnotRequired].isna()
+        | (~df_check[ICPCnotRequired].isin([1, "true"]))
     ]
     # get all the locations where DateOfInitialCPC is null
     df_check = df_check[df_check[DateOfInitialCPC].isna()]
@@ -131,13 +133,19 @@ def test_validate():
                 LAchildID: "child3",
                 CINdetailsID: "cinID3",
                 DateOfInitialCPC: pd.NA,  # 6 nan but also ICPC not required
-                ICPCnotRequired: 1,
+                ICPCnotRequired: "true",
             },
             {  # pass
                 LAchildID: "child3",
                 CINdetailsID: "cinID3",
                 DateOfInitialCPC: pd.NA,  # 7 not more than one nan authorisation date in group
                 ICPCnotRequired: pd.NA,
+            },
+            {  # pass
+                LAchildID: "child3",
+                CINdetailsID: "cinID3",
+                DateOfInitialCPC: pd.NA,  # 6 nan but also ICPC not required
+                ICPCnotRequired: 1,
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-    print(df_merged['LAchildID'])
+    print(df_merged["LAchildID"])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -199,13 +199,13 @@ def test_validate():
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentActualStartDate": "01/03/2000",
                 "AssessmentAuthorisationDate": "01/04/2000",
-            },  
+            },
             {
                 "LAchildID": "child5",
                 "CINdetailsID": "cinID1",
-                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentActualStartDate": "01/09/2000",
                 "AssessmentAuthorisationDate": "01/10/2000",
             },
         ]

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -23,7 +23,7 @@ ReferenceDate = Header.ReferenceDate
 @rule_definition(
     code=8863,
     module=CINTable.Assessments,
-    message="An Assessment is shown as starting when there is another Assessment ongoing",
+    message="An Assessment is shown as starting when there is another Assessment ongoing.",
     affected_fields=[AssessmentActualStartDate, AssessmentAuthorisationDate],
 )
 def validate(
@@ -102,7 +102,7 @@ def validate(
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)
     ].reset_index()
-
+    print(df_merged['LAchildID'])
     # create an identifier for each error instance.
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -196,6 +196,18 @@ def test_validate():
                 "AssessmentActualStartDate": "26/09/2000",  # 7 Pass: not between "26/10/2000" and "31/03/2001"
                 "AssessmentAuthorisationDate": pd.NA,
             },
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/03/2000",  
+                "AssessmentAuthorisationDate": "01/04/2000",
+            },  
+            {
+                "LAchildID": "child5",
+                "CINdetailsID": "cinID1",
+                "AssessmentActualStartDate": "01/09/2000", 
+                "AssessmentAuthorisationDate": "01/10/2000",
+            },
         ]
     )
 
@@ -282,5 +294,5 @@ def test_validate():
     assert result.definition.code == 8863
     assert (
         result.definition.message
-        == "An Assessment is shown as starting when there is another Assessment ongoing"
+        == "An Assessment is shown as starting when there is another Assessment ongoing."
     )

--- a/cin_validator/rules/cin2022_23/rule_8863.py
+++ b/cin_validator/rules/cin2022_23/rule_8863.py
@@ -88,16 +88,16 @@ def validate(
 
     # Determine whether assessment overlaps with another assessment
     ass_started_after_start = (
-        df_merged["AssessmentActualStartDate_ass"]
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts later than 2 starts
         >= df_merged["AssessmentActualStartDate_ass2"]
     )
     ass_started_before_end = (
-        df_merged["AssessmentActualStartDate_ass"]
-        <= df_merged["AssessmentAuthorisationDate_ass"]
-    ) & df_merged["AssessmentAuthorisationDate_ass"].notna()
+        df_merged["AssessmentActualStartDate_ass"]  # 1 starts earlier than 2 finishes
+        <= df_merged["AssessmentAuthorisationDate_ass2"]
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].notna()
     ass_started_before_refdate = (
         df_merged["AssessmentActualStartDate_ass"] <= reference_date
-    ) & df_merged["AssessmentAuthorisationDate_ass"].isna()
+    ) & df_merged["AssessmentAuthorisationDate_ass2"].isna()
 
     df_merged = df_merged[
         ass_started_after_start & (ass_started_before_end | ass_started_before_refdate)


### PR DESCRIPTION
closes #310 

The following is being wrongly failed

  ```
              <Section47>
                    <DateOfInitialCPC>SAME DATE</DateOfInitialCPC>
                </Section47>
              <Section47>
              </Section47>
                <ChildProtectionPlans>
                    <CPPstartDate>SAME DATE</CPPstartDate>
                </ChildProtectionPlans>

```
It fails because there is an s47 module with no date, where if there is a module with a passing date, this child should pass and the no date s47 module should not matter.

The fix needed to fail CINdetails modules with children with no dates, and no correct dates, but allow modules with multiple s47s, some of which pass, to pass. This involves finding out is a CINdetails module has both s47 modules with, and without dates, and if that was the case, only testing the ones WITH dates. If these fail, the child still fails.