### PR TITLE
Bugfix/fix inequalities

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_4017.py
+++ b/cin_validator/rules/cin2022_23/rule_4017.py
@@ -62,7 +62,7 @@ def validate(
 
     # Get rows where CPPstartDate is after CINPlanStartDate
     # and CPPstartDate before CINPlanEndDate (or if null, before/on ReferenceDate)
-    cpp_start_after_cin_start = df_merged[CPPstartDate] >= df_merged[CINPlanStartDate]
+    cpp_start_after_cin_start = df_merged[CPPstartDate] > df_merged[CINPlanStartDate]
     cpp_start_before_cin_end = (
         df_merged[CPPstartDate] < df_merged[CINPlanEndDate]
     ) & df_merged[CINPlanEndDate].notna()

--- a/cin_validator/rules/cin2022_23/rule_8620.py
+++ b/cin_validator/rules/cin2022_23/rule_8620.py
@@ -18,6 +18,7 @@ CINclosureDate = CINdetails.CINclosureDate
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
     code=8620,
@@ -43,8 +44,8 @@ def validate(
     df = df[df[CINclosureDate].notna()]
     df = df[
         ~(
-            (df[CINclosureDate] > collection_start)
-            & (df[CINclosureDate] < collection_end)
+            (df[CINclosureDate] >= collection_start)
+            & (df[CINclosureDate] <= collection_end)
         )
     ]
     failing_indices = df.index
@@ -68,6 +69,8 @@ def test_validate():
             {
                 CINclosureDate: "01/10/2022"
             },  # 2 fail: October 1st is after March 31st, 2022. It is out of range
+            {CINclosureDate: "01/04/2021"},  # Pass, first day of census period
+            {CINclosureDate: "31/03/2021"},  # Pass, last day of census period
         ]
     )
 

--- a/cin_validator/rules/cin2022_23/rule_8675Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8675Q.py
@@ -46,7 +46,7 @@ def validate(
     # then <S47ActualStartDate> (N00148) should not be before the <ReferenceDate> (N00603) minus 15 working days
     no_cpc = df[DateOfInitialCPC].isna()
     icpc_false = df[ICPCnotReqiured] == "false"
-    before_15b = df[S47ActualStartDate] > (collection_end - england_working_days(15))
+    before_15b = df[S47ActualStartDate] < (collection_end - england_working_days(15))
     condition = (no_cpc & icpc_false) & (before_15b)
 
     # get all the data that fits the failing condition. Reset the index so that ROW_ID now becomes a column of df
@@ -84,10 +84,10 @@ def test_validate():
 
     section47 = pd.DataFrame(
         [
-            {  # 0 fail
+            {  # 0 fail, no ICPCnotrequied as true or InitialCPC, and date is more than 15 days before end of census year
                 "LAchildID": "child1",
                 "DateOfInitialCPC": pd.NA,
-                "S47ActualStartDate": "29/03/2022",
+                "S47ActualStartDate": "29/01/2022",
                 "ICPCnotRequired": "false",
             },
             {  # 1 ignore DateOfInitialCPC notna
@@ -99,8 +99,8 @@ def test_validate():
             {  # 2 pass. more than 15 working days before ref date
                 "LAchildID": "child3",
                 "DateOfInitialCPC": pd.NA,
-                "S47ActualStartDate": "25/01/2022",
-                "ICPCnotRequired": "true",
+                "S47ActualStartDate": "25/03/2022",
+                "ICPCnotRequired": "false",
             },
             {  # ignore S47ActualStartDate isna
                 "LAchildID": "child3",
@@ -156,7 +156,7 @@ def test_validate():
             {
                 "ERROR_ID": (
                     "child1",
-                    pd.to_datetime("29/03/2022", format="%d/%m/%Y", errors="coerce"),
+                    pd.to_datetime("29/01/2022", format="%d/%m/%Y", errors="coerce"),
                     "false",
                 ),
                 "ROW_ID": [0],

--- a/cin_validator/rules/cin2022_23/rule_8675Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8675Q.py
@@ -17,6 +17,7 @@ LAchildID = Section47.LAchildID
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here, in place of 8675Q


### PR DESCRIPTION
Fixes rules which failed children by using faulty inequalities.

8675Q failed children who had their S47date within 15 working days of the end of the census for not having their CPC done yet, or their ICPCnotRequired as false, when this is supposed to fail rows where it's been more than 15 days and these haven't been done. Swapped the direction of the inequality.

8620 failed children who ended on the first or last day of the census year which is unintended, added equals to the inequalities to allow this.

4017 failed children who had CPP plans ending the same day their CIN plan started, added an equals to the inequality to fix.