### PR TITLE
Bugfix/fix merges

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_4000.py
+++ b/cin_validator/rules/cin2022_23/rule_4000.py
@@ -40,15 +40,16 @@ def validate(
         | (df_CINdetails[ReferralNFA] == True)
     ]
 
-    df_merged = df_cpd.merge(
-        df_CINdetails,
+    df_merged = df_CINdetails.merge(
+        df_cpd,
         left_on=["LAchildID", "CINdetailsID"],
         right_on=["LAchildID", "CINdetailsID"],
-        how="left",
-        suffixes=("_cpd", "_cin"),
+        how="inner",
+        suffixes=("_cin", "_cpd"),
     )
 
     df_merged = df_merged.reset_index()
+
 
     df_merged["ERROR_ID"] = tuple(
         zip(
@@ -89,6 +90,10 @@ def test_validate():
                 "LAchildID": "child1",
                 "CINdetailsID": "CDID2",
             },
+            {
+                "LAchildID": "child4",
+                "CINdetailsID": "CDID6",
+            },
         ]
     )
     sample_cin = pd.DataFrame(
@@ -107,6 +112,11 @@ def test_validate():
                 "LAchildID": "child3",  # Pass, no module
                 "CINdetailsID": "CDID6",
                 "ReferralNFA": "1",
+            },
+            {
+                "LAchildID": "child4",  # Pass, referral NFA is false
+                "CINdetailsID": "CDID6",
+                "ReferralNFA": "false",
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_4000.py
+++ b/cin_validator/rules/cin2022_23/rule_4000.py
@@ -50,7 +50,6 @@ def validate(
 
     df_merged = df_merged.reset_index()
 
-
     df_merged["ERROR_ID"] = tuple(
         zip(
             df_merged["LAchildID"],

--- a/cin_validator/rules/cin2022_23/rule_8867.py
+++ b/cin_validator/rules/cin2022_23/rule_8867.py
@@ -59,7 +59,7 @@ def validate(
         df_ass,
         left_on=["LAchildID", "CINdetailsID"],
         right_on=["LAchildID", "CINdetailsID"],
-        how="left",
+        how="inner",
         suffixes=("_cind", "_ass"),
     )
 
@@ -131,6 +131,11 @@ def test_validate():
                 "LAchildID": "child5",
                 "CINdetailsID": "CDID5",
                 "CINclosureDate": "15/11/2001",  # Fails (no Assessment Authorisation Date entered)
+            },
+            {
+                "LAchildID": "child6",
+                "CINdetailsID": "CDID5",
+                "CINclosureDate": "15/11/2001",  # Passes, no Assessment module
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_8867.py
+++ b/cin_validator/rules/cin2022_23/rule_8867.py
@@ -17,6 +17,7 @@ AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 LAchildID = Assessments.LAchildID
 CINdetailsAssID = Assessments.CINdetailsID
 
+
 # define characteristics of rule
 @rule_definition(
     code=8867,


### PR DESCRIPTION
Fixed issues in 4000 and 8867 where they picked up and failed either children who didn't have a module and failed them as if they did. It was because the merges were either the wrong way round, or left instead of inner.