### PR TITLE
bugfix 1560Q

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_1560Q.py
+++ b/cin_validator/rules/cin2022_23/rule_1560Q.py
@@ -28,6 +28,9 @@ def validate(
     df = data_container[ChildIdentifiers]
 
     # <FormerUPN> (N00002) where present should be in the correct format, as specified in the data table
+    # Note, there are multiple types of former UPN, there are Temporary UPNs which end in a letter, and
+    # those where a child is assigned a UPN but then another is identified for them having been used previously.
+    # If this was only a check for temporary UPNs, it would check that the last character was a letter.
 
     #  filter rows of df where the UPN column doesn't have Na/NaN values
     df = df.loc[df[FormerUPN].notna()]
@@ -36,11 +39,9 @@ def validate(
     # FormerUPN is not 13 characters long
     check_length = df[FormerUPN].str.len() != 13
     # FormerUPN does not contain a full digit between edges.
-    digit_within = ~df[FormerUPN].str[1:-1].str.isdigit()
-    # FormerUPN's edges are not characters of th alphabet
-    check_edges = (~df[FormerUPN].str[0].str.isalpha()) | (
-        ~df[FormerUPN].str[-1].str.isalpha()
-    )
+    digit_within = ~df[FormerUPN].str[1:].str.isdigit()
+    # FormerUPN's first letter is meant to be a letter
+    check_edges = ~df[FormerUPN].str[0].str.isalpha()
 
     failing_indices = df[check_length | digit_within | check_edges].index
 
@@ -53,9 +54,10 @@ def test_validate():
     child_identifiers = pd.DataFrame(
         [
             {FormerUPN: pd.NA},  # 0 ignore
-            {FormerUPN: "X98765432123B"},  # 1 pass
-            {FormerUPN: "X0000y000000K"},  # 2 fail non-alphabet within
-            {FormerUPN: "X9872123B"},  # 3 wrong length
+            {FormerUPN: "X987654321231"},  # 1 pass
+            {FormerUPN: "X0000y0000007"},  # 2 fail non-alphabet within
+            {FormerUPN: "X98721238"},  # 3 wrong length
+            {FormerUPN: "E000215119000"},
         ]
     )
 

--- a/cin_validator/rules/cin2022_23/rule_1560Q.py
+++ b/cin_validator/rules/cin2022_23/rule_1560Q.py
@@ -28,19 +28,19 @@ def validate(
     df = data_container[ChildIdentifiers]
 
     # <FormerUPN> (N00002) where present should be in the correct format, as specified in the data table
+
     # Note, there are multiple types of former UPN, there are Temporary UPNs which end in a letter, and
     # those where a child is assigned a UPN but then another is identified for them having been used previously.
-    # If this was only a check for temporary UPNs, it would check that the last character was a letter.
+    # If this was only a check for temporary UPNs, it would check that the last character was a letter. However, it checks more generally.
 
     #  filter rows of df where the UPN column doesn't have Na/NaN values
     df = df.loc[df[FormerUPN].notna()]
 
-    # Flag locations where
-    # FormerUPN is not 13 characters long
+    # Flag locations where FormerUPN is not 13 characters long
     check_length = df[FormerUPN].str.len() != 13
-    # FormerUPN does not contain a full digit between edges.
+    # Flag locations where FormerUPN's last twelve characters do not form a full digit
     digit_within = ~df[FormerUPN].str[1:].str.isdigit()
-    # FormerUPN's first letter is meant to be a letter
+    # Flag locations where FormerUPN's first character is not a letter
     check_edges = ~df[FormerUPN].str[0].str.isalpha()
 
     failing_indices = df[check_length | digit_within | check_edges].index


### PR DESCRIPTION
 fixed check to allow temporary and misassigned UPNs

   `<FormerUPN> (N00002) where present should be in the correct format, as specified in the data table 
`
Note, there are multiple types of former UPN, there are Temporary UPNs which end in a letter, and those where a child is assigned a UPN but then another is identified for them having been used previously. If this was only a check for temporary UPNs, it would check that the last character was a letter.

@tab1tha feel free to not merge these and close it if you don't agree with the change