### PR TITLE
1560Q fix pytest

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_1560Q.py
+++ b/cin_validator/rules/cin2022_23/rule_1560Q.py
@@ -59,8 +59,6 @@ def test_validate():
             {FormerUPN: "X98721238"},  # 3 wrong length
             {FormerUPN: "E000215119000"},
             {FormerUPN: "X987654321231"},  # 1 pass
-            {FormerUPN: "X0000y0000007"},  # 2 fail non-alphabet within
-            {FormerUPN: "X98721238"},  # 3 wrong length
             {FormerUPN: "E000215119000"},
         ]
     )


### PR DESCRIPTION
Removed some accidentally repeated entries in the Pytest which caused a rows to fail which weren't anticipated to.