### PR TITLE
mvp init file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If it is cloned locally, use `pre-commit install` to install the pre-commit hook
 ## Run
 - To test that all the rules pass their Pytests and will validate data as expected:  
 `python -m cin_validator test`
+- To select the ruleset that should be tested, include the path. For example, for 2023/24 rules do
+`python -m cin_validator test --ruleset "rules.cin_2023_24"`
 - To list all rules that are present:  
 `python -m cin_validator list`
 - To run rules on a file and generate a table of error locations:  

--- a/cin_validator/rules/cin_2023_24/__init__.py
+++ b/cin_validator/rules/cin_2023_24/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+__all__ = [p.stem for p in Path(__file__).parent.glob("*.py") if p.stem != "__init__"]
+
+from . import *


### PR DESCRIPTION
This adds an init file to the 23_24 folder so that the 23_24 rules can be implemented and run independently. 
The ability to import rules from 22_23 will be added in a later pull request.