### PR TITLE
fixes issue column bug in 2991Q

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_2991Q.py
+++ b/cin_validator/rules/cin2022_23/rule_2991Q.py
@@ -166,7 +166,7 @@ def test_validate():
     assert issue_table == Section47
 
     issue_columns = issues.columns
-    assert issue_columns == [CINdetailsID]
+    assert issue_columns == [LAchildID]
 
     issue_rows = issues.row_df
     assert len(issue_rows) == 3


### PR DESCRIPTION
Pytest in live version of 2991Q fails because the wrong issue column is selected after it was changed away from CINdetailsID to fix a different bug. This fixes the Pytest changing it to LAchildID to match the validation code.