### PR TITLE
Bugfix ammended rules: updates 7 rules to 22/23 v1.2 standards

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_2991Q.py
+++ b/cin_validator/rules/cin2022_23/rule_2991Q.py
@@ -17,7 +17,7 @@ CINdetailsID = Assessments.CINdetailsID
     code="2991Q",
     module=CINTable.CINdetails,
     rule_type=RuleType.QUERY,
-    message="Please check: A Section 47 module is recorded and there is no assessment on the episode",
+    message="Please check and either amend data or provide a reason: A Section 47 module is recorded and there is no assessment on the episode",
     affected_fields=[
         CINdetailsID,
     ],
@@ -203,5 +203,5 @@ def test_validate():
     assert result.definition.code == "2991Q"
     assert (
         result.definition.message
-        == "Please check: A Section 47 module is recorded and there is no assessment on the episode"
+        == "Please check and either amend data or provide a reason: A Section 47 module is recorded and there is no assessment on the episode"
     )

--- a/cin_validator/rules/cin2022_23/rule_8530Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8530Q.py
@@ -29,7 +29,7 @@ ReferenceDate = Header.ReferenceDate
     code="8530Q",
     module=CINTable.ChildIdentifiers,
     rule_type=RuleType.QUERY,
-    message="Please check: Expected Date of Birth is outside the expected range for this census (March to December of the Census Year end)",
+    message="Please check and either amend data or provide a reason: Expected Date of Birth is outside the expected range for this census (March to December of the Census Year end)",
     affected_fields=[ExpectedPersonBirthDate],
 )
 def validate(
@@ -156,5 +156,5 @@ def test_validate():
     assert result.definition.code == "8530Q"
     assert (
         result.definition.message
-        == "Please check: Expected Date of Birth is outside the expected range for this census (March to December of the Census Year end)"
+        == "Please check and either amend data or provide a reason: Expected Date of Birth is outside the expected range for this census (March to December of the Census Year end)"
     )

--- a/cin_validator/rules/cin2022_23/rule_8535Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8535Q.py
@@ -16,7 +16,7 @@ LAchildID = ChildIdentifiers.LAchildID
     code="8535Q",
     module=CINTable.ChildIdentifiers,
     rule_type=RuleType.QUERY,
-    message="Child’s date of death should not be prior to the date of birth",
+    message="Please check and either amend data or provide a reason: Child’s date of death should not be prior to the date of birth",
     affected_fields=[PersonDeathDate, PersonBirthDate],
 )
 def validate(
@@ -146,5 +146,5 @@ def test_validate():
     assert result.definition.code == "8535Q"
     assert (
         result.definition.message
-        == "Child’s date of death should not be prior to the date of birth"
+        == "Please check and either amend data or provide a reason: Child’s date of death should not be prior to the date of birth"
     )

--- a/cin_validator/rules/cin2022_23/rule_8670Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8670Q.py
@@ -30,7 +30,7 @@ ReferenceDate = Header.ReferenceDate
     code="8670Q",
     module=CINTable.Assessments,
     rule_type=RuleType.QUERY,
-    message="Please check: Assessment started more than 45 working days before the end of the census year. However, there is no Assessment end date.",
+    message="Please check and either amend data or provide a reason: Assessment started more than 45 working days before the end of the census year. However, there is no Assessment end date.",
     affected_fields=[AssessmentActualStartDate],
 )
 def validate(
@@ -166,5 +166,5 @@ def test_validate():
     assert result.definition.code == "8670Q"
     assert (
         result.definition.message
-        == "Please check: Assessment started more than 45 working days before the end of the census year. However, there is no Assessment end date."
+        == "Please check and either amend data or provide a reason: Assessment started more than 45 working days before the end of the census year. However, there is no Assessment end date."
     )

--- a/cin_validator/rules/cin2022_23/rule_8675Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8675Q.py
@@ -24,7 +24,7 @@ ReferenceDate = Header.ReferenceDate
     code="8675Q",
     rule_type=RuleType.QUERY,
     module=CINTable.Section47,
-    message="Please check: S47 Enquiry started more than 15 working days before the end of the census year. However, there is no date of Initial Child Protection Conference.",
+    message="Please check and either amend data or provide a reason: S47 Enquiry started more than 15 working days before the end of the census year. However, there is no date of Initial Child Protection Conference.",
     affected_fields=[DateOfInitialCPC, S47ActualStartDate],
 )
 def validate(
@@ -186,5 +186,5 @@ def test_validate():
     assert result.definition.code == "8675Q"
     assert (
         result.definition.message
-        == "Please check: S47 Enquiry started more than 15 working days before the end of the census year. However, there is no date of Initial Child Protection Conference."
+        == "Please check and either amend data or provide a reason: S47 Enquiry started more than 15 working days before the end of the census year. However, there is no date of Initial Child Protection Conference."
     )

--- a/cin_validator/rules/cin2022_23/rule_8775Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8775Q.py
@@ -19,6 +19,7 @@ CINclosureDate = CINdetails.CINclosureDate
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here, in place of 8775Q
@@ -224,4 +225,7 @@ def test_validate():
 
     # replace 8775Q with the rule code and put the appropriate message in its place too.
     assert result.definition.code == "8775Q"
-    assert result.definition.message == "Please check and either amend data or provide a reason: Child is over 25 years old"
+    assert (
+        result.definition.message
+        == "Please check and either amend data or provide a reason: Child is over 25 years old"
+    )

--- a/cin_validator/rules/cin2022_23/rule_8775Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8775Q.py
@@ -28,7 +28,7 @@ ReferenceDate = Header.ReferenceDate
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.ChildIdentifiers,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
-    message="Please check: Child is over 25 years old",
+    message="Please check and either amend data or provide a reason: Child is over 25 years old",
     # The column names tend to be the words within the < > signs in the github issue description.
     affected_fields=[
         PersonBirthDate,
@@ -224,4 +224,4 @@ def test_validate():
 
     # replace 8775Q with the rule code and put the appropriate message in its place too.
     assert result.definition.code == "8775Q"
-    assert result.definition.message == "Please check: Child is over 25 years old"
+    assert result.definition.message == "Please check and either amend data or provide a reason: Child is over 25 years old"

--- a/cin_validator/rules/cin2022_23/rule_8825Q.py
+++ b/cin_validator/rules/cin2022_23/rule_8825Q.py
@@ -24,7 +24,7 @@ ReasonForClosure = CINdetails.ReasonForClosure
     module=CINTable.CINdetails,
     rule_type=RuleType.QUERY,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
-    message="Reason for Closure code RC8 (case closed after assessment) has been returned but there is no assessment present for the episode.",
+    message="Please check and either amend or provide a reason: Reason for Closure code RC8 (case closed after assessment) has been returned but there is no assessment present for the episode.",
     # The column names tend to be the words within the < > signs in the github issue description.
     affected_fields=[
         ReasonForClosure,
@@ -214,5 +214,5 @@ def test_validate():
     assert result.definition.code == "8825Q"
     assert (
         result.definition.message
-        == "Reason for Closure code RC8 (case closed after assessment) has been returned but there is no assessment present for the episode."
+        == "Please check and either amend or provide a reason: Reason for Closure code RC8 (case closed after assessment) has been returned but there is no assessment present for the episode."
     )


### PR DESCRIPTION
Closes #342 

The following rules been changed to automatic ‘ok’ queries: 2991Q, 8530Q, 8535Q, 8670Q, 8675Q, 8775Q and 8825Q.

This PR updates these rules to include the appropriate message in the error report.