### PR TITLE
Refactor/remove ERROR_ID

### DIFF
--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -247,6 +247,9 @@ class CinValidationSession:
         self.full_issue_df = include_issue_child(self.full_issue_df, raw_data)
         self.user_report = create_user_report(self.full_issue_df, raw_data)
 
+        # regularise column names
+        self.full_issue_df.rename(columns={"ROW_ID": "row_id"}, inplace=True)
+
     def get_rules_to_run(self, registry, selected_rules):
         """
         Filters rules to be run based on user's selection in the frontend.
@@ -357,7 +360,6 @@ class CinValidationSession:
 
         rules_to_run = self.get_rules_to_run(registry, selected_rules)
         for rule in rules_to_run:
-            # data_files = self.data_files.__deepcopy__({})
             data_files = copy.deepcopy(enum_data_files)
             ctx = RuleContext(rule)
             try:

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -247,8 +247,12 @@ class CinValidationSession:
         self.full_issue_df = include_issue_child(self.full_issue_df, raw_data)
         self.user_report = create_user_report(self.full_issue_df, raw_data)
 
-        # regularise column names
+        # regularise full_issue_df
         self.full_issue_df.rename(columns={"ROW_ID": "row_id"}, inplace=True)
+        self.full_issue_df.drop(columns=["ERROR_ID"])
+        self.full_issue_df.drop_duplicates(
+            ["LAchildID", "rule_code", "columns_affected", "row_id"], inplace=True
+        )
 
     def get_rules_to_run(self, registry, selected_rules):
         """

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -61,14 +61,14 @@ def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     )
 
     # make return data json-serialisable
-    issue_report = validator.full_issue_df.to_json(
+
+    # what the frontend will display
+    issue_report = validator.full_issue_df.drop(columns=["ERROR_ID"]).to_json(
         orient="records"
-    )  # what the frontend will display
-    rule_defs = validator.rule_descriptors.to_json(
-        orient="records"
-    )  # what the frontend will display
-    user_report = validator.user_report.to_json(
-        orient="records"
-    )  # what the user will download
+    )
+    rule_defs = validator.rule_descriptors.to_json(orient="records")
+
+    # what the user will download
+    user_report = validator.user_report.to_json(orient="records")
 
     return issue_report, rule_defs, json_data_files, user_report

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -63,9 +63,7 @@ def cin_validate(cin_data, selected_rules=None, ruleset="rules.cin2022_23"):
     # make return data json-serialisable
 
     # what the frontend will display
-    issue_report = validator.full_issue_df.drop(columns=["ERROR_ID"]).to_json(
-        orient="records"
-    )
+    issue_report = validator.full_issue_df.to_json(orient="records")
     rule_defs = validator.rule_descriptors.to_json(orient="records")
 
     # what the user will download


### PR DESCRIPTION
Location linking in the frontend is seen to work to a desirable level without ERROR_IDs and incorporating them has a high cost-benefit ratio so it is being de-prioritized.

For now, the ERROR_ID has been left to show up in the user report so that users can filter by ERROR_ID to levels of linking that are more specific than table-column-row. We'll need to find out if users use it in this way, else it can be removed from the user report too.

The concept of ERROR_IDs is tightly coupled with all ,but one, rule types. So totally deleting it from the backend is a significant piece of work.

Effect of change:
The command line run-all function returned 1699 rows before this change. Now, it returns 1690 rows as rows ERROR_ID is no longer used as a marker of uniqueness data entries with the same table-column-row are dropped as duplicates irrespective of their ERROR_IDs.