### PR TITLE
Bugfix 1520

### DIFF
--- a/cin_validator/rules/cin2022_23/rule_1520.py
+++ b/cin_validator/rules/cin2022_23/rule_1520.py
@@ -29,6 +29,8 @@ def validate(
     df.index.name = "ROW_ID"
 
     # Each pupil <UPN> (N00001) must be unique across all pupils in the extract
+
+    df = df[df[UPN].notna()]
     df_issues = df[df.duplicated(subset=[UPN], keep=False)].reset_index()
 
     link_id = tuple(
@@ -63,6 +65,14 @@ def test_validate():
             {
                 "LAchildID": "child3",
                 "UPN": "12345",
+            },
+            {
+                "LAchildID": "child4",
+                "UPN": pd.NA,
+            },
+            {
+                "LAchildID": "child4",
+                "UPN": pd.NA,
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_1520.py
+++ b/cin_validator/rules/cin2022_23/rule_1520.py
@@ -14,7 +14,6 @@ from cin_validator.test_engine import run_rule
 
 ChildIdentifiers = CINTable.ChildIdentifiers
 UPN = ChildIdentifiers.UPN
-LAchildID = ChildIdentifiers.LAchildID
 
 
 @rule_definition(
@@ -31,11 +30,7 @@ def validate(
 
     # Each pupil <UPN> (N00001) must be unique across all pupils in the extract
 
-    # absent UPNs should not be flagged as duplicates.
     df = df[df[UPN].notna()]
-    # If it's a record of the same child, the UPN should not be marked as duplicate.
-    df.drop_duplicates(subset=[LAchildID, UPN], inplace=True)
-
     df_issues = df[df.duplicated(subset=[UPN], keep=False)].reset_index()
 
     link_id = tuple(
@@ -60,32 +55,24 @@ def test_validate():
     child_identifiers = pd.DataFrame(
         [
             {
-                "LAchildID": "child1",  # fail: UPN is same as in another child
+                "LAchildID": "child1",
                 "UPN": "1234",
             },
             {
-                "LAchildID": "child2",  # fail: UPN is same as in another child
+                "LAchildID": "child2",
                 "UPN": "1234",
             },
             {
-                "LAchildID": "child3",  # pass: UPN is unique
+                "LAchildID": "child3",
                 "UPN": "12345",
             },
             {
-                "LAchildID": "child4",  # ignore: UPN is absent
+                "LAchildID": "child4",
                 "UPN": pd.NA,
             },
             {
-                "LAchildID": "child5",  # ignore: UPN is absent
+                "LAchildID": "child4",
                 "UPN": pd.NA,
-            },
-            {
-                "LAchildID": "child6",  # pass: UPN is unique for child
-                "UPN": "12",
-            },
-            {
-                "LAchildID": "child6",  # pass: UPN is unique for child
-                "UPN": "12",
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_1520.py
+++ b/cin_validator/rules/cin2022_23/rule_1520.py
@@ -14,6 +14,7 @@ from cin_validator.test_engine import run_rule
 
 ChildIdentifiers = CINTable.ChildIdentifiers
 UPN = ChildIdentifiers.UPN
+LAchildID = ChildIdentifiers.LAchildID
 
 
 @rule_definition(
@@ -30,7 +31,11 @@ def validate(
 
     # Each pupil <UPN> (N00001) must be unique across all pupils in the extract
 
+    # absent UPNs should not be flagged as duplicates.
     df = df[df[UPN].notna()]
+    # If it's a record of the same child, the UPN should not be marked as duplicate.
+    df.drop_duplicates(subset=[LAchildID, UPN], inplace=True)
+
     df_issues = df[df.duplicated(subset=[UPN], keep=False)].reset_index()
 
     link_id = tuple(
@@ -55,24 +60,32 @@ def test_validate():
     child_identifiers = pd.DataFrame(
         [
             {
-                "LAchildID": "child1",
+                "LAchildID": "child1",  # fail: UPN is same as in another child
                 "UPN": "1234",
             },
             {
-                "LAchildID": "child2",
+                "LAchildID": "child2",  # fail: UPN is same as in another child
                 "UPN": "1234",
             },
             {
-                "LAchildID": "child3",
+                "LAchildID": "child3",  # pass: UPN is unique
                 "UPN": "12345",
             },
             {
-                "LAchildID": "child4",
+                "LAchildID": "child4",  # ignore: UPN is absent
                 "UPN": pd.NA,
             },
             {
-                "LAchildID": "child4",
+                "LAchildID": "child5",  # ignore: UPN is absent
                 "UPN": pd.NA,
+            },
+            {
+                "LAchildID": "child6",  # pass: UPN is unique for child
+                "UPN": "12",
+            },
+            {
+                "LAchildID": "child6",  # pass: UPN is unique for child
+                "UPN": "12",
             },
         ]
     )


### PR DESCRIPTION
- Ensures that missing UPNs are not marked as duplicates.

The second commit made an exception for when the childIDs of the duplicate UPNs are the same. However, this too should not be allowed as each child should appear only once in the childIdentifiers table.