### PR TITLE
Bugfix 2885

### DIFF
--- a/Documentation/rule_logic_demos/rule2885_multitable_independent_compare.ipynb
+++ b/Documentation/rule_logic_demos/rule2885_multitable_independent_compare.ipynb
@@ -1,0 +1,497 @@
+{
+  "metadata": {
+    "language_info": {
+      "codemirror_mode": {
+        "name": "python",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8"
+    },
+    "kernelspec": {
+      "name": "python",
+      "display_name": "Python (Pyodide)",
+      "language": "python"
+    }
+  },
+  "nbformat_minor": 4,
+  "nbformat": 4,
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": "import pandas as pd\npd.options.mode.chained_assignment = None",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "ChildProtectionPlans = \"ChildProtectionPlans\"\nCINdetails = \"CINdetails\"\nSection47 = \"Section47\"\nCPPstartDate = \"CPPstartDate\"\nLAchildID = \"LAchildID\"\nCINdetailsID = \"CINdetailsID\"\nDateOfInitialCPC = \"DateOfInitialCPC\"\nHeader = \"Header\"\nReferenceDate = \"ReferenceDate\"",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp = pd.DataFrame(\n        [    # child1: Simulates multiple cin modules with one out of census period, and multiple CPPs within the same CIN.\n            {   \"LAchildID\": \"child1\",                \n                \"CINdetailsID\": \"cinID1\",\n                \"CPPstartDate\": \"26/05/2021\",  #  passes in section47\n            },\n            {   \"LAchildID\": \"child1\",                \n                \"CINdetailsID\": \"cinID1\",      # simulates multiple CPPs with same LAchildID-CINdetailsID where some fail, some pass.\n                \"CPPstartDate\": \"26/06/2021\",  #  # fail. fails both section47 and cin\n            },\n            {   \"LAchildID\": \"child1\",\n                \"CINdetailsID\": \"cinID2\",\n                \"CPPstartDate\": \"27/06/2002\",  # ignore. would've failed but ignored. Not in period of census\n            },\n            # child2: fail in section47, pass in cin\n            {   \"LAchildID\": \"child2\",\n                \"CINdetailsID\": \"cinID1\",\n                \"CPPstartDate\": \"26/05/2021\",  # fail. fails in section47, pass in cin not considered.\n            },\n            # child3: multiple cin details modules.\n            {   \"LAchildID\": \"child3\",\n                \"CINdetailsID\": \"cinID1\",\n                \"CPPstartDate\": \"26/05/2021\",  # fail. fails in both section47 and cin\n            },\n            {  \n                \"LAchildID\": \"child3\",\n                \"CINdetailsID\": \"cinID2\",\n                \"CPPstartDate\": pd.NA,  # ignore. cppstartdate is absent\n            },\n            {   \"LAchildID\": \"child3\",\n                \"CINdetailsID\": \"cinID3\",\n                \"CPPstartDate\": \"07/02/2022\",  # fail. fails both section47 and cin\n            },\n            {   \"LAchildID\": \"child3\",\n                \"CINdetailsID\": \"cinID4\",\n                \"CPPstartDate\": \"14/03/2022\",  # fail. fails in section47, pass in cin not considered.\n            },\n            # child 5: date present in section47 and absent in cin\n            {\n                \"LAchildID\": \"child5\",\n                \"CINdetailsID\": \"cinID4\",\n                \"CPPstartDate\": \"19/07/2021\", # passes in section47\n            },\n            # child 6: no DateOfInitialCPC recorded in cin or section47 table\n            {\n                \"LAchildID\": \"child6\",\n                \"CINdetailsID\": \"cinID4\",\n                \"CPPstartDate\": \"19/07/2021\", # fail\n            },\n            # child 8: multiple section47s in the same cin module where some pass and others fail.\n            {\n                \"LAchildID\": \"child8\",\n                \"CINdetailsID\": \"cinID1\",\n                \"CPPstartDate\": \"20/10/2021\", # passes in section_47\n            },\n            # child 9: present in cin, absent in section47\n            {\n                \"LAchildID\": \"child9\",\n                \"CINdetailsID\": \"cinID1\",\n                \"CPPstartDate\": \"20/10/2021\",  # passes in cin\n            },\n        ]\n    )",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "df_47 = pd.DataFrame(\n        [\n            {  # 0 pass\n                \"LAchildID\": \"child1\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # pass. same as cppstartdate\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {  # 1 ignored\n                \"LAchildID\": \"child1\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # ignore. cppstartdate not in period of census\n                \"CINdetailsID\": \"cinID2\",\n            },\n            {  # 2 pass\n                \"LAchildID\": \"child2\",\n                \"DateOfInitialCPC\": \"30/05/2021\", # fail. not the same\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {  # 4 absent, ignored\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # ignore. cppstartdate is absent.\n                \"CINdetailsID\": \"cinID2\",\n            },\n            {  # 5 fail\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # fail. not the same\n                \"CINdetailsID\": \"cinID3\",\n            },\n            {  # 6 pass\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": pd.NA, # fail. not the same\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child5\",\n                \"DateOfInitialCPC\": \"19/07/2021\", # pass. same as cppstartdate\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child5\",\n                \"DateOfInitialCPC\": pd.NA, # pass since other section47 in same modeule passes.\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child6\",\n                \"DateOfInitialCPC\": pd.NA, # fail. not the same\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child8\",\n                \"DateOfInitialCPC\": \"20/10/2021\", # pass. same as cpp_start_date\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {\n                \"LAchildID\": \"child8\",\n                \"DateOfInitialCPC\": \"22/07/2021\", # pass since other section47 in the same CINmodule passes.\n                \"CINdetailsID\": \"cinID1\",\n            },\n        ]\n    )",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cin = pd.DataFrame(\n        [\n            {  # 0 pass\n                \"LAchildID\": \"child1\",\n                \"DateOfInitialCPC\": \"26/10/2020\", # ignore fail. not the same but present in section47 table\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {  # 1 ignore\n                \"LAchildID\": \"child1\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # ignore. cppstartdate not in period of census\n                \"CINdetailsID\": \"cinID2\",\n            },\n            {  # 2 pass\n                \"LAchildID\": \"child2\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # ignore fail. could've passed but present in section47\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {  # 3 fail\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": \"28/05/2021\", # fail. not the same and no corresponding section47\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {  # 4 ignore\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": \"26/05/2021\", # ignore. cppstartdate is absent\n                \"CINdetailsID\": \"cinID2\",\n            },\n            {  # 5 fail\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": \"26/05/2003\", # ignore fail. not the same and has corresponding section47.\n                \"CINdetailsID\": \"cinID3\",\n            },\n            {  # 6 pass\n                \"LAchildID\": \"child3\",\n                \"DateOfInitialCPC\": \"14/03/2022\", # ignore fail. could've passed but present in section47\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child5\",\n                \"DateOfInitialCPC\": pd.NA, # ignore fail. not the same  and has corresponding section47.\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child6\",\n                \"DateOfInitialCPC\": pd.NA, # ignore fail. not the same and has corresponding section47\n                \"CINdetailsID\": \"cinID4\",\n            },\n            {\n                \"LAchildID\": \"child7\",\n                \"DateOfInitialCPC\": pd.NA, # ignore. not present in cpp table.\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {\n                \"LAchildID\": \"child8\",\n                \"DateOfInitialCPC\": pd.NA, # passes in section47\n                \"CINdetailsID\": \"cinID1\",\n            },\n            {\n                \"LAchildID\": \"child9\",\n                \"CINdetailsID\": \"cinID1\",\n                \"DateOfInitialCPC\": \"20/10/2021\",  # passes in cin\n            },\n        ]\n    )",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp[CPPstartDate] = pd.to_datetime(\n    df_cpp[CPPstartDate], format=\"%d/%m/%Y\", errors=\"coerce\"\n)\ndf_47[\"DateOfInitialCPC\"] = pd.to_datetime(\n    df_47[\"DateOfInitialCPC\"], format=\"%d/%m/%Y\", errors=\"coerce\"\n)\ndf_cin[\"DateOfInitialCPC\"] = pd.to_datetime(\n    df_cin[\"DateOfInitialCPC\"], format=\"%d/%m/%Y\", errors=\"coerce\"\n)",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "# Before you begin, rename the index so that the initial row positions can be kept intact.\ndf_cpp.index.name = \"ROW_ID\"\ndf_47.index.name = \"ROW_ID\"\ndf_cin.index.name = \"ROW_ID\"\n\n# Resetting the index causes the ROW_IDs to become columns of their respective DataFrames\n# so that they can come along when the merge is done.\n\ndf_cpp.reset_index(inplace=True)\ndf_47.reset_index(inplace=True)\ndf_cin.reset_index(inplace=True)",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "execution_count": 8,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "    ROW_ID LAchildID CINdetailsID CPPstartDate\n0        0    child1       cinID1   2021-05-26\n1        1    child1       cinID1   2021-06-26\n2        2    child1       cinID2   2002-06-27\n3        3    child2       cinID1   2021-05-26\n4        4    child3       cinID1   2021-05-26\n5        5    child3       cinID2          NaT\n6        6    child3       cinID3   2022-02-07\n7        7    child3       cinID4   2022-03-14\n8        8    child5       cinID4   2021-07-19\n9        9    child6       cinID4   2021-07-19\n10      10    child8       cinID1   2021-10-20\n11      11    child9       cinID1   2021-10-20",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2</td>\n      <td>child1</td>\n      <td>cinID2</td>\n      <td>2002-06-27</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5</td>\n      <td>child3</td>\n      <td>cinID2</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11</td>\n      <td>child9</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "# CPPstartDate is nan\ndf_cpp = df_cpp[df_cpp[CPPstartDate].notna()]\n\n# CPPstartDate is not in period of census\ndf_cpp[CPPstartDate] = pd.to_datetime(df_cpp[CPPstartDate], format=\"%d/%m/%Y\", errors=\"coerce\")\n\ncollection_start= pd.to_datetime(\"01/04/2021\", format=\"%d/%m/%Y\", errors=\"coerce\") \ncollection_end= pd.to_datetime(\"31/03/2022\", format=\"%d/%m/%Y\", errors=\"coerce\")\n\nstart_date_present = df_cpp[CPPstartDate].notna()\nwithin_period = (df_cpp[CPPstartDate] >= collection_start) & (df_cpp[CPPstartDate] <= collection_end)\ndf_cpp = df_cpp[start_date_present & within_period]\ndf_cpp",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "execution_count": 9,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "    ROW_ID LAchildID CINdetailsID CPPstartDate\n0        0    child1       cinID1   2021-05-26\n1        1    child1       cinID1   2021-06-26\n3        3    child2       cinID1   2021-05-26\n4        4    child3       cinID1   2021-05-26\n6        6    child3       cinID3   2022-02-07\n7        7    child3       cinID4   2022-03-14\n8        8    child5       cinID4   2021-07-19\n9        9    child6       cinID4   2021-07-19\n10      10    child8       cinID1   2021-10-20\n11      11    child9       cinID1   2021-10-20",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11</td>\n      <td>child9</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": "If CPPstartDate is present, it should be equal to at least one Section47 DateOfInitialCPC",
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47 = df_cpp.merge(df_47, on=[LAchildID, CINdetailsID],how=\"inner\", suffixes=[\"_cpp\", \"_47\"])\ndf_cpp_47",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "execution_count": 10,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC\n0           0    child1       cinID1   2021-05-26          0       2021-05-26\n1           1    child1       cinID1   2021-06-26          0       2021-05-26\n2           3    child2       cinID1   2021-05-26          2       2021-05-30\n3           6    child3       cinID3   2022-02-07          4       2021-05-26\n4           7    child3       cinID4   2022-03-14          5              NaT\n5           8    child5       cinID4   2021-07-19          6       2021-07-19\n6           8    child5       cinID4   2021-07-19          7              NaT\n7           9    child6       cinID4   2021-07-19          8              NaT\n8          10    child8       cinID1   2021-10-20          9       2021-10-20\n9          10    child8       cinID1   2021-10-20         10       2021-07-22",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>2</td>\n      <td>2021-05-30</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>4</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>5</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>6</td>\n      <td>2021-07-19</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>7</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>9</td>\n      <td>2021-10-20</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>10</td>\n      <td>2021-07-22</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": "children who pass the rule",
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_pass = df_cpp_47[df_cpp_47[CPPstartDate] == df_cpp_47[DateOfInitialCPC]]\ndf_cpp_47_pass",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "execution_count": 11,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC\n0           0    child1       cinID1   2021-05-26          0       2021-05-26\n5           8    child5       cinID4   2021-07-19          6       2021-07-19\n8          10    child8       cinID1   2021-10-20          9       2021-10-20",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>6</td>\n      <td>2021-07-19</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>9</td>\n      <td>2021-10-20</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_failable = (df_cpp_47[df_cpp_47[CPPstartDate] != df_cpp_47[DateOfInitialCPC]])\ndf_cpp_47_failable",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "execution_count": 12,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC\n1           1    child1       cinID1   2021-06-26          0       2021-05-26\n2           3    child2       cinID1   2021-05-26          2       2021-05-30\n3           6    child3       cinID3   2022-02-07          4       2021-05-26\n4           7    child3       cinID4   2022-03-14          5              NaT\n6           8    child5       cinID4   2021-07-19          7              NaT\n7           9    child6       cinID4   2021-07-19          8              NaT\n9          10    child8       cinID1   2021-10-20         10       2021-07-22",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>2</td>\n      <td>2021-05-30</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>4</td>\n      <td>2021-05-26</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>5</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>7</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>10</td>\n      <td>2021-07-22</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_failable[\"ERROR_ID\"] = tuple(zip(df_cpp_47_failable[LAchildID], df_cpp_47_failable[CINdetailsID]))\ndf_cpp_47_failable",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "execution_count": 13,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC  \\\n1           1    child1       cinID1   2021-06-26          0       2021-05-26   \n2           3    child2       cinID1   2021-05-26          2       2021-05-30   \n3           6    child3       cinID3   2022-02-07          4       2021-05-26   \n4           7    child3       cinID4   2022-03-14          5              NaT   \n6           8    child5       cinID4   2021-07-19          7              NaT   \n7           9    child6       cinID4   2021-07-19          8              NaT   \n9          10    child8       cinID1   2021-10-20         10       2021-07-22   \n\n           ERROR_ID  \n1  (child1, cinID1)  \n2  (child2, cinID1)  \n3  (child3, cinID3)  \n4  (child3, cinID4)  \n6  (child5, cinID4)  \n7  (child6, cinID4)  \n9  (child8, cinID1)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>2</td>\n      <td>2021-05-30</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>4</td>\n      <td>2021-05-26</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>5</td>\n      <td>NaT</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>7</td>\n      <td>NaT</td>\n      <td>(child5, cinID4)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>10</td>\n      <td>2021-07-22</td>\n      <td>(child8, cinID1)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_pass[\"ERROR_ID\"] = tuple(zip(df_cpp_47_pass[LAchildID], df_cpp_47_pass[CINdetailsID]))\ndf_cpp_47_pass",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "execution_count": 14,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC  \\\n0           0    child1       cinID1   2021-05-26          0       2021-05-26   \n5           8    child5       cinID4   2021-07-19          6       2021-07-19   \n8          10    child8       cinID1   2021-10-20          9       2021-10-20   \n\n           ERROR_ID  \n0  (child1, cinID1)  \n5  (child5, cinID4)  \n8  (child8, cinID1)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>6</td>\n      <td>2021-07-19</td>\n      <td>(child5, cinID4)</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>9</td>\n      <td>2021-10-20</td>\n      <td>(child8, cinID1)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_fail = df_cpp_47_failable[~(df_cpp_47_failable[\"ERROR_ID\"].isin(df_cpp_47_pass[\"ERROR_ID\"]))]\ndf_cpp_47_fail",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 15,
+      "outputs": [
+        {
+          "execution_count": 15,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC  \\\n2           3    child2       cinID1   2021-05-26          2       2021-05-30   \n3           6    child3       cinID3   2022-02-07          4       2021-05-26   \n4           7    child3       cinID4   2022-03-14          5              NaT   \n7           9    child6       cinID4   2021-07-19          8              NaT   \n\n           ERROR_ID  \n2  (child2, cinID1)  \n3  (child3, cinID3)  \n4  (child3, cinID4)  \n7  (child6, cinID4)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>2</td>\n      <td>2021-05-30</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>4</td>\n      <td>2021-05-26</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>5</td>\n      <td>NaT</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": "The pass/fail of a CPPstartDate should not affect the pass/fail of other CPPstartDate in its CIN module. Hence, another fail dataset is created which includes CPPstartDate in the filter. This ensures that within one CIN details module, it is possible to have a CPPstartDate that passes and one that fails.",
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_failable[\"ERROR_startdate\"] = tuple(zip(df_cpp_47_failable[LAchildID], df_cpp_47_failable[CINdetailsID], df_cpp_47_failable[CPPstartDate]))\ndf_cpp_47_pass[\"ERROR_startdate\"] = tuple(zip(df_cpp_47_pass[LAchildID], df_cpp_47_pass[CINdetailsID], df_cpp_47_pass[CPPstartDate]))\ndf_cpp_47_startdate_fail = df_cpp_47_failable[~(df_cpp_47_failable[\"ERROR_startdate\"].isin(df_cpp_47_pass[\"ERROR_startdate\"]))]\ndf_cpp_47_startdate_fail",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 16,
+      "outputs": [
+        {
+          "execution_count": 16,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC  \\\n1           1    child1       cinID1   2021-06-26          0       2021-05-26   \n2           3    child2       cinID1   2021-05-26          2       2021-05-30   \n3           6    child3       cinID3   2022-02-07          4       2021-05-26   \n4           7    child3       cinID4   2022-03-14          5              NaT   \n7           9    child6       cinID4   2021-07-19          8              NaT   \n\n           ERROR_ID                        ERROR_startdate  \n1  (child1, cinID1)  (child1, cinID1, 2021-06-26 00:00:00)  \n2  (child2, cinID1)  (child2, cinID1, 2021-05-26 00:00:00)  \n3  (child3, cinID3)  (child3, cinID3, 2022-02-07 00:00:00)  \n4  (child3, cinID4)  (child3, cinID4, 2022-03-14 00:00:00)  \n7  (child6, cinID4)  (child6, cinID4, 2021-07-19 00:00:00)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n      <th>ERROR_startdate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>0</td>\n      <td>2021-05-26</td>\n      <td>(child1, cinID1)</td>\n      <td>(child1, cinID1, 2021-06-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>2</td>\n      <td>2021-05-30</td>\n      <td>(child2, cinID1)</td>\n      <td>(child2, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>4</td>\n      <td>2021-05-26</td>\n      <td>(child3, cinID3)</td>\n      <td>(child3, cinID3, 2022-02-07 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>5</td>\n      <td>NaT</td>\n      <td>(child3, cinID4)</td>\n      <td>(child3, cinID4, 2022-03-14 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n      <td>(child6, cinID4)</td>\n      <td>(child6, cinID4, 2021-07-19 00:00:00)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_cin = df_cpp.merge(df_cin, on=[LAchildID, CINdetailsID], suffixes=[\"_cpp\", \"_cin\"])\ndf_cpp_cin_pass = df_cpp_cin[df_cpp_cin[CPPstartDate] == df_cpp_cin[DateOfInitialCPC]]\ndf_cpp_cin_failable = df_cpp_cin[df_cpp_cin[CPPstartDate] != df_cpp_cin[DateOfInitialCPC]]\n\ndf_cpp_cin_failable[\"ERROR_ID\"] = tuple(zip(df_cpp_cin_failable[LAchildID], df_cpp_cin_failable[CINdetailsID]))\ndf_cpp_cin_pass[\"ERROR_ID\"] = tuple(zip(df_cpp_cin_pass[LAchildID], df_cpp_cin_pass[CINdetailsID]))\n\ndf_cpp_cin_failable[\"ERROR_startdate\"] = tuple(zip(df_cpp_cin_failable[LAchildID], df_cpp_cin_failable[CINdetailsID], df_cpp_cin_failable[CPPstartDate]))\ndf_cpp_cin_pass[\"ERROR_startdate\"] = tuple(zip(df_cpp_cin_pass[LAchildID], df_cpp_cin_pass[CINdetailsID], df_cpp_cin_pass[CPPstartDate]))\n\n\ndf_cpp_cin_fail = df_cpp_cin_failable[~(df_cpp_cin_failable[\"ERROR_ID\"].isin(df_cpp_cin_pass[\"ERROR_ID\"]))]\n\ndf_cpp_cin_fail",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 17,
+      "outputs": [
+        {
+          "execution_count": 17,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_cin  \\\n0           0    child1       cinID1   2021-05-26           0   \n1           1    child1       cinID1   2021-06-26           0   \n3           4    child3       cinID1   2021-05-26           3   \n4           6    child3       cinID3   2022-02-07           5   \n6           8    child5       cinID4   2021-07-19           7   \n7           9    child6       cinID4   2021-07-19           8   \n8          10    child8       cinID1   2021-10-20          10   \n\n  DateOfInitialCPC          ERROR_ID                        ERROR_startdate  \n0       2020-10-26  (child1, cinID1)  (child1, cinID1, 2021-05-26 00:00:00)  \n1       2020-10-26  (child1, cinID1)  (child1, cinID1, 2021-06-26 00:00:00)  \n3       2021-05-28  (child3, cinID1)  (child3, cinID1, 2021-05-26 00:00:00)  \n4       2003-05-26  (child3, cinID3)  (child3, cinID3, 2022-02-07 00:00:00)  \n6              NaT  (child5, cinID4)  (child5, cinID4, 2021-07-19 00:00:00)  \n7              NaT  (child6, cinID4)  (child6, cinID4, 2021-07-19 00:00:00)  \n8              NaT  (child8, cinID1)  (child8, cinID1, 2021-10-20 00:00:00)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_cin</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n      <th>ERROR_startdate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>0</td>\n      <td>2020-10-26</td>\n      <td>(child1, cinID1)</td>\n      <td>(child1, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>0</td>\n      <td>2020-10-26</td>\n      <td>(child1, cinID1)</td>\n      <td>(child1, cinID1, 2021-06-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>3</td>\n      <td>2021-05-28</td>\n      <td>(child3, cinID1)</td>\n      <td>(child3, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>5</td>\n      <td>2003-05-26</td>\n      <td>(child3, cinID3)</td>\n      <td>(child3, cinID3, 2022-02-07 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>7</td>\n      <td>NaT</td>\n      <td>(child5, cinID4)</td>\n      <td>(child5, cinID4, 2021-07-19 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n      <td>(child6, cinID4)</td>\n      <td>(child6, cinID4, 2021-07-19 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>10</td>\n      <td>NaT</td>\n      <td>(child8, cinID1)</td>\n      <td>(child8, cinID1, 2021-10-20 00:00:00)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_cin_startdate_fail = df_cpp_cin_failable[~(df_cpp_cin_failable[\"ERROR_startdate\"].isin(df_cpp_cin_pass[\"ERROR_startdate\"]))]\ndf_cpp_cin_startdate_fail",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 18,
+      "outputs": [
+        {
+          "execution_count": 18,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_cin  \\\n0           0    child1       cinID1   2021-05-26           0   \n1           1    child1       cinID1   2021-06-26           0   \n3           4    child3       cinID1   2021-05-26           3   \n4           6    child3       cinID3   2022-02-07           5   \n6           8    child5       cinID4   2021-07-19           7   \n7           9    child6       cinID4   2021-07-19           8   \n8          10    child8       cinID1   2021-10-20          10   \n\n  DateOfInitialCPC          ERROR_ID                        ERROR_startdate  \n0       2020-10-26  (child1, cinID1)  (child1, cinID1, 2021-05-26 00:00:00)  \n1       2020-10-26  (child1, cinID1)  (child1, cinID1, 2021-06-26 00:00:00)  \n3       2021-05-28  (child3, cinID1)  (child3, cinID1, 2021-05-26 00:00:00)  \n4       2003-05-26  (child3, cinID3)  (child3, cinID3, 2022-02-07 00:00:00)  \n6              NaT  (child5, cinID4)  (child5, cinID4, 2021-07-19 00:00:00)  \n7              NaT  (child6, cinID4)  (child6, cinID4, 2021-07-19 00:00:00)  \n8              NaT  (child8, cinID1)  (child8, cinID1, 2021-10-20 00:00:00)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_cin</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n      <th>ERROR_startdate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>0</td>\n      <td>2020-10-26</td>\n      <td>(child1, cinID1)</td>\n      <td>(child1, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>0</td>\n      <td>2020-10-26</td>\n      <td>(child1, cinID1)</td>\n      <td>(child1, cinID1, 2021-06-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>3</td>\n      <td>2021-05-28</td>\n      <td>(child3, cinID1)</td>\n      <td>(child3, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>5</td>\n      <td>2003-05-26</td>\n      <td>(child3, cinID3)</td>\n      <td>(child3, cinID3, 2022-02-07 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>7</td>\n      <td>NaT</td>\n      <td>(child5, cinID4)</td>\n      <td>(child5, cinID4, 2021-07-19 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n      <td>(child6, cinID4)</td>\n      <td>(child6, cinID4, 2021-07-19 00:00:00)</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>10</td>\n      <td>NaT</td>\n      <td>(child8, cinID1)</td>\n      <td>(child8, cinID1, 2021-10-20 00:00:00)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_47[\"ERROR_ID\"] = tuple(zip(df_47[LAchildID], df_47[CINdetailsID]))\ndf_47",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 19,
+      "outputs": [
+        {
+          "execution_count": 19,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "    ROW_ID LAchildID DateOfInitialCPC CINdetailsID          ERROR_ID\n0        0    child1       2021-05-26       cinID1  (child1, cinID1)\n1        1    child1       2021-05-26       cinID2  (child1, cinID2)\n2        2    child2       2021-05-30       cinID1  (child2, cinID1)\n3        3    child3       2021-05-26       cinID2  (child3, cinID2)\n4        4    child3       2021-05-26       cinID3  (child3, cinID3)\n5        5    child3              NaT       cinID4  (child3, cinID4)\n6        6    child5       2021-07-19       cinID4  (child5, cinID4)\n7        7    child5              NaT       cinID4  (child5, cinID4)\n8        8    child6              NaT       cinID4  (child6, cinID4)\n9        9    child8       2021-10-20       cinID1  (child8, cinID1)\n10      10    child8       2021-07-22       cinID1  (child8, cinID1)",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>DateOfInitialCPC</th>\n      <th>CINdetailsID</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>2021-05-26</td>\n      <td>cinID1</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>2021-05-26</td>\n      <td>cinID2</td>\n      <td>(child1, cinID2)</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2</td>\n      <td>child2</td>\n      <td>2021-05-30</td>\n      <td>cinID1</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child3</td>\n      <td>2021-05-26</td>\n      <td>cinID2</td>\n      <td>(child3, cinID2)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>2021-05-26</td>\n      <td>cinID3</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5</td>\n      <td>child3</td>\n      <td>NaT</td>\n      <td>cinID4</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>child5</td>\n      <td>2021-07-19</td>\n      <td>cinID4</td>\n      <td>(child5, cinID4)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>child5</td>\n      <td>NaT</td>\n      <td>cinID4</td>\n      <td>(child5, cinID4)</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8</td>\n      <td>child6</td>\n      <td>NaT</td>\n      <td>cinID4</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>child8</td>\n      <td>2021-10-20</td>\n      <td>cinID1</td>\n      <td>(child8, cinID1)</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>2021-07-22</td>\n      <td>cinID1</td>\n      <td>(child8, cinID1)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_cin_fail_no_47 = df_cpp_cin_fail[~(df_cpp_cin_fail[\"ERROR_ID\"].isin(df_47[\"ERROR_ID\"]))]\ndf_cpp_cin_fail_no_47",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 20,
+      "outputs": [
+        {
+          "execution_count": 20,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_cin  \\\n3           4    child3       cinID1   2021-05-26           3   \n\n  DateOfInitialCPC          ERROR_ID                        ERROR_startdate  \n3       2021-05-28  (child3, cinID1)  (child3, cinID1, 2021-05-26 00:00:00)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_cin</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n      <th>ERROR_startdate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>3</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>3</td>\n      <td>2021-05-28</td>\n      <td>(child3, cinID1)</td>\n      <td>(child3, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_cin_startdate_fail_no47 = df_cpp_cin_startdate_fail[~(df_cpp_cin_startdate_fail[\"ERROR_ID\"].isin(df_47[\"ERROR_ID\"]))]\ndf_cpp_cin_startdate_fail_no47",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "execution_count": 21,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_cin  \\\n3           4    child3       cinID1   2021-05-26           3   \n\n  DateOfInitialCPC          ERROR_ID                        ERROR_startdate  \n3       2021-05-28  (child3, cinID1)  (child3, cinID1, 2021-05-26 00:00:00)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_cin</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n      <th>ERROR_startdate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>3</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>3</td>\n      <td>2021-05-28</td>\n      <td>(child3, cinID1)</td>\n      <td>(child3, cinID1, 2021-05-26 00:00:00)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_47_fail",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 22,
+      "outputs": [
+        {
+          "execution_count": 22,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID_cpp LAchildID CINdetailsID CPPstartDate  ROW_ID_47 DateOfInitialCPC  \\\n2           3    child2       cinID1   2021-05-26          2       2021-05-30   \n3           6    child3       cinID3   2022-02-07          4       2021-05-26   \n4           7    child3       cinID4   2022-03-14          5              NaT   \n7           9    child6       cinID4   2021-07-19          8              NaT   \n\n           ERROR_ID  \n2  (child2, cinID1)  \n3  (child3, cinID3)  \n4  (child3, cinID4)  \n7  (child6, cinID4)  ",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID_cpp</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ROW_ID_47</th>\n      <th>DateOfInitialCPC</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>2</td>\n      <td>2021-05-30</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>4</td>\n      <td>2021-05-26</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>5</td>\n      <td>NaT</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>8</td>\n      <td>NaT</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp[\"ERROR_ID\"] = tuple(zip(df_cpp[LAchildID], df_cpp[CINdetailsID]))\ndf_cpp",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "execution_count": 23,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "    ROW_ID LAchildID CINdetailsID CPPstartDate          ERROR_ID\n0        0    child1       cinID1   2021-05-26  (child1, cinID1)\n1        1    child1       cinID1   2021-06-26  (child1, cinID1)\n3        3    child2       cinID1   2021-05-26  (child2, cinID1)\n4        4    child3       cinID1   2021-05-26  (child3, cinID1)\n6        6    child3       cinID3   2022-02-07  (child3, cinID3)\n7        7    child3       cinID4   2022-03-14  (child3, cinID4)\n8        8    child5       cinID4   2021-07-19  (child5, cinID4)\n9        9    child6       cinID4   2021-07-19  (child6, cinID4)\n10      10    child8       cinID1   2021-10-20  (child8, cinID1)\n11      11    child9       cinID1   2021-10-20  (child9, cinID1)",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>(child3, cinID1)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8</td>\n      <td>child5</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>(child5, cinID4)</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>(child8, cinID1)</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11</td>\n      <td>child9</td>\n      <td>cinID1</td>\n      <td>2021-10-20</td>\n      <td>(child9, cinID1)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cin[\"ERROR_ID\"] = tuple(zip(df_cin[LAchildID], df_cin[CINdetailsID]))\ndf_cin",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 24,
+      "outputs": [
+        {
+          "execution_count": 24,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "    ROW_ID LAchildID DateOfInitialCPC CINdetailsID          ERROR_ID\n0        0    child1       2020-10-26       cinID1  (child1, cinID1)\n1        1    child1       2021-05-26       cinID2  (child1, cinID2)\n2        2    child2       2021-05-26       cinID1  (child2, cinID1)\n3        3    child3       2021-05-28       cinID1  (child3, cinID1)\n4        4    child3       2021-05-26       cinID2  (child3, cinID2)\n5        5    child3       2003-05-26       cinID3  (child3, cinID3)\n6        6    child3       2022-03-14       cinID4  (child3, cinID4)\n7        7    child5              NaT       cinID4  (child5, cinID4)\n8        8    child6              NaT       cinID4  (child6, cinID4)\n9        9    child7              NaT       cinID1  (child7, cinID1)\n10      10    child8              NaT       cinID1  (child8, cinID1)\n11      11    child9       2021-10-20       cinID1  (child9, cinID1)",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>DateOfInitialCPC</th>\n      <th>CINdetailsID</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>child1</td>\n      <td>2020-10-26</td>\n      <td>cinID1</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>2021-05-26</td>\n      <td>cinID2</td>\n      <td>(child1, cinID2)</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2</td>\n      <td>child2</td>\n      <td>2021-05-26</td>\n      <td>cinID1</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child3</td>\n      <td>2021-05-28</td>\n      <td>cinID1</td>\n      <td>(child3, cinID1)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>2021-05-26</td>\n      <td>cinID2</td>\n      <td>(child3, cinID2)</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5</td>\n      <td>child3</td>\n      <td>2003-05-26</td>\n      <td>cinID3</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>2022-03-14</td>\n      <td>cinID4</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>child5</td>\n      <td>NaT</td>\n      <td>cinID4</td>\n      <td>(child5, cinID4)</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8</td>\n      <td>child6</td>\n      <td>NaT</td>\n      <td>cinID4</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>child7</td>\n      <td>NaT</td>\n      <td>cinID1</td>\n      <td>(child7, cinID1)</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10</td>\n      <td>child8</td>\n      <td>NaT</td>\n      <td>cinID1</td>\n      <td>(child8, cinID1)</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11</td>\n      <td>child9</td>\n      <td>2021-10-20</td>\n      <td>cinID1</td>\n      <td>(child9, cinID1)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cpp_issues = df_cpp[(df_cpp[\"ROW_ID\"].isin(df_cpp_47_startdate_fail[\"ROW_ID_cpp\"])) | (df_cpp[\"ROW_ID\"].isin(df_cpp_cin_startdate_fail_no47[\"ROW_ID_cpp\"]))] \ndf_cpp_issues",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "execution_count": 25,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID LAchildID CINdetailsID CPPstartDate          ERROR_ID\n1       1    child1       cinID1   2021-06-26  (child1, cinID1)\n3       3    child2       cinID1   2021-05-26  (child2, cinID1)\n4       4    child3       cinID1   2021-05-26  (child3, cinID1)\n6       6    child3       cinID3   2022-02-07  (child3, cinID3)\n7       7    child3       cinID4   2022-03-14  (child3, cinID4)\n9       9    child6       cinID4   2021-07-19  (child6, cinID4)",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>CINdetailsID</th>\n      <th>CPPstartDate</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>child1</td>\n      <td>cinID1</td>\n      <td>2021-06-26</td>\n      <td>(child1, cinID1)</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child2</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>(child2, cinID1)</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>child3</td>\n      <td>cinID1</td>\n      <td>2021-05-26</td>\n      <td>(child3, cinID1)</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>child3</td>\n      <td>cinID3</td>\n      <td>2022-02-07</td>\n      <td>(child3, cinID3)</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>child3</td>\n      <td>cinID4</td>\n      <td>2022-03-14</td>\n      <td>(child3, cinID4)</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>child6</td>\n      <td>cinID4</td>\n      <td>2021-07-19</td>\n      <td>(child6, cinID4)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_47_issues = df_47[df_47[\"ROW_ID\"].isin(df_cpp_47_fail[\"ROW_ID_47\"])].groupby(\"ERROR_ID\", group_keys=False)[\"ROW_ID\"].apply(list).reset_index()\ndf_47_issues",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 26,
+      "outputs": [
+        {
+          "execution_count": 26,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "           ERROR_ID ROW_ID\n0  (child2, cinID1)    [2]\n1  (child3, cinID3)    [4]\n2  (child3, cinID4)    [5]\n3  (child6, cinID4)    [8]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ERROR_ID</th>\n      <th>ROW_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>(child2, cinID1)</td>\n      <td>[2]</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>(child3, cinID3)</td>\n      <td>[4]</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>(child3, cinID4)</td>\n      <td>[5]</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>(child6, cinID4)</td>\n      <td>[8]</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "df_cin_issues = df_cin[df_cin[\"ROW_ID\"].isin(df_cpp_cin_fail_no_47[\"ROW_ID_cin\"])]\ndf_cin_issues",
+      "metadata": {
+        "trusted": true
+      },
+      "execution_count": 27,
+      "outputs": [
+        {
+          "execution_count": 27,
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   ROW_ID LAchildID DateOfInitialCPC CINdetailsID          ERROR_ID\n3       3    child3       2021-05-28       cinID1  (child3, cinID1)",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ROW_ID</th>\n      <th>LAchildID</th>\n      <th>DateOfInitialCPC</th>\n      <th>CINdetailsID</th>\n      <th>ERROR_ID</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>child3</td>\n      <td>2021-05-28</td>\n      <td>cinID1</td>\n      <td>(child3, cinID1)</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": "",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/cin_validator/rules/cin2022_23/rule_2885.py
+++ b/cin_validator/rules/cin2022_23/rule_2885.py
@@ -290,6 +290,12 @@ def test_validate():
                 "CINdetailsID": "cinID1",
                 "CPPstartDate": "20/10/2021",  # passes in section_47
             },
+            # child 9: present in cin, absent in section47
+            {
+                "LAchildID": "child9",
+                "CINdetailsID": "cinID1",
+                "CPPstartDate": "20/10/2021",  # passes in cin
+            },
         ]
     )
     sample_section47 = pd.DataFrame(
@@ -407,6 +413,11 @@ def test_validate():
                 "LAchildID": "child8",
                 "DateOfInitialCPC": pd.NA,  # passes in section47
                 "CINdetailsID": "cinID1",
+            },
+            {
+                "LAchildID": "child9",
+                "CINdetailsID": "cinID1",
+                "DateOfInitialCPC": "20/10/2021",  # passes in cin
             },
         ]
     )

--- a/cin_validator/rules/cin2022_23/rule_2885.py
+++ b/cin_validator/rules/cin2022_23/rule_2885.py
@@ -80,7 +80,7 @@ def validate(
 
     # get only the section47 rows where cppstartdate exists and is within period.
     df_cpp_47 = df_cpp.merge(
-        df_47, on=[LAchildID, CINdetailsID], how="left", suffixes=["_cpp", "_47"]
+        df_47, on=[LAchildID, CINdetailsID], how="inner", suffixes=["_cpp", "_47"]
     )
 
     # FIND LOCATIONS THAT FAIL THE RULE


### PR DESCRIPTION
- locations that are not found in the section47 table shouldn't fail unless they are seen to fail in the CIN table.
- test data has been added to check this.
- a jupyter notebook that runs the rule on the test data has been added to show the interactive flow of the rule logic.