### PR TITLE
fix: error when no rule fails.

### DIFF
--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -106,6 +106,11 @@ def include_issue_child(issue_df, cin_data):
         # work around: ensure that columns from both sources have the same type to prevent merge error
         table_df["ROW_ID"] = table_df["ROW_ID"].astype("int64")
         linker_df["ROW_ID"] = linker_df["ROW_ID"].astype("int64")
+
+        if not linker_df.empty:
+            # if failing locations have been found, remove the dummy LAchildID column to make way for the real one.
+            table_df.drop(columns="LAchildID", inplace=True)
+
         # map the child ids back to issue_df
         table_df = table_df.merge(linker_df, on=["ROW_ID"], how="left")
 

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -354,7 +354,19 @@ class CinValidationSession:
 
         enum_data_files = enum_keys(self.data_files)
         self.issue_instances = pd.DataFrame()
-        self.full_issue_df = pd.DataFrame()
+        self.full_issue_df = pd.DataFrame(
+            columns=[
+                "tables_affected",
+                "columns_affected",
+                "ROW_ID",
+                "ERROR_ID",
+                "rule_code",
+                "rule_description",
+                "rule_type",
+                "la_level",
+                "LAchildID",
+            ]
+        )
         self.rules_passed = []
 
         self.rules_broken = []

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -147,7 +147,7 @@ def create_user_report(issue_df, cin_data):
             column_data = cin_data[table][column]
             # fancy indexing. get all the values for a sequence of row positions in a column.
             column_values = column_data[column_rows]
-            column_values.rename("values_flagged", inplace=True)
+            column_values.rename("value_flagged", inplace=True)
             column_values.index.name = "ROW_ID"
             values_df = column_values.reset_index()
             values_df = values_df.assign(ROW_ID=values_df["ROW_ID"].astype("object"))
@@ -157,6 +157,21 @@ def create_user_report(issue_df, cin_data):
         reports.extend(table_reports)
     # add in the la-level locations
     reports.append(no_table)
+
+    # ensure that all required column names will be present in the result.
+    full_report_cols_df = pd.DataFrame(
+        columns=[
+            "ERROR_ID",
+            "LAchildID",
+            "rule_code",
+            "tables_affected",
+            "columns_affected",
+            "ROW_ID",
+            "value_flagged",
+            "rule_description",
+        ]
+    )
+    reports.append(full_report_cols_df)
 
     full_report = pd.concat(reports, ignore_index=True)
 
@@ -169,7 +184,7 @@ def create_user_report(issue_df, cin_data):
             "tables_affected",
             "columns_affected",
             "ROW_ID",
-            "values_flagged",
+            "value_flagged",
             "rule_description",
         ]
     ]

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -156,7 +156,12 @@ def create_user_report(issue_df, cin_data):
             column_values.index.name = "ROW_ID"
             values_df = column_values.reset_index()
             values_df = values_df.assign(ROW_ID=values_df["ROW_ID"].astype("object"))
+
+            # work around: ensure that columns from both sources (user data and rule output) have the same type to prevent merge error
+            only_column["ROW_ID"] = only_column["ROW_ID"].astype("int64")
+            values_df["ROW_ID"] = values_df["ROW_ID"].astype("int64")
             report_df = only_column.merge(values_df, on="ROW_ID")
+
             table_reports.append(report_df)
 
         reports.extend(table_reports)


### PR DESCRIPTION
1. https://github.com/data-to-insight/CIN-validator/pull/442/commits/d7657cbee74a914deacdffe81be38c153271cb6b initialises full_issue_df with all the column names it is supposed to have so that even if the structure of some rules doesn't generate a column, keyErrors wouldn't be raised when full_issue_df is processed. `python -m cin_validator run-all fake_data\fake_CIN_data.xml --select "100"` which returns a type 0 issue table (no ERROR_ID or LAchildID) now runs without errors.
2. https://github.com/data-to-insight/CIN-validator/pull/442/commits/6147036ff36009f5354cf3b33b22fcaef923fbaf does the same for full report such that `python -m cin_validator run-all fake_data\fake_CIN_data.xml --select "1520"`  or select 2883, la-level rule and rule-that-passes respectively, no longer break because the "values_flagged column cannot be found" when creating the user report.