### PR TITLE
redirect la_issues into separate object

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -101,7 +101,7 @@ def run_all(filename: str, ruleset, select, output):
 
     # print(issue_instances)
     print(full_issue_df)
-    # print(validator.rule_descriptors)
+    print(validator.la_rule_issues)
     # print(validator.user_report)
 
 

--- a/cin_validator/cin_validator_class.py
+++ b/cin_validator/cin_validator_class.py
@@ -318,8 +318,9 @@ class CinValidationSession:
         if error_df_lengths.max() == 0:
             # if the rule didn't push to any of the issue accumulators, then it didn't find any issues in the file.
             self.rules_passed.append(rule.code)
-        elif error_df_lengths.max() == 4:
-            # this is a return level validation rule. It has no locations attached so it is only displayed in the rule descriptions.
+        elif error_df_lengths.idxmax() == 4:
+            # If the maximum value is in position 4, this is a return level validation rule.
+            # It has no locations attached so it is only displayed in the rule descriptions.
             self.la_rules_broken.append(issue_dfs_per_rule[4])
         else:
             # get the rule type based on which attribute had elements pushed to it (i.e non-zero length)
@@ -414,8 +415,5 @@ class CinValidationSession:
         child_level_rules = pd.DataFrame(
             {"Rule code": self.rules_broken, "Rule Message": self.rule_messages}
         )
-        la_level_rules = pd.DataFrame(self.la_rules_broken)
-        if not la_level_rules.empty:
-            self.rule_descriptors = pd.concat([child_level_rules, la_level_rules])
-        else:
-            self.rule_descriptors = child_level_rules
+        # self.la_rules_broken is a list of issue_dfs, one per la-level rule that failed.
+        self.la_rule_issues = pd.concat(self.la_rules_broken)

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -92,9 +92,9 @@ def cin_validate(cin_data, selected_rules=None, ruleset="cin2022_23"):
 
     # what the frontend will display
     issue_report = validator.full_issue_df.to_json(orient="records")
-    rule_defs = validator.rule_descriptors.to_json(orient="records")
+    la_rule_issues = validator.la_rule_issues.to_json(orient="records")
 
     # what the user will download
     user_report = validator.user_report.to_json(orient="records")
 
-    return issue_report, rule_defs, json_data_files, user_report
+    return issue_report, la_rule_issues, json_data_files, user_report


### PR DESCRIPTION
La-level issues are structured differently and should be displayed in the frontend differently.  This is because they are not attached to any child or data table in particular. 

The changes in this pull request
- separate la-level issues from the full_issue_df as `la_rule_issues`
- replace rule_defs ( validator.rule_descriptors) in the output array to the frontend since the frontend extracts these values from full_issue_df directly. [care was taken not to disrupt the order of the elements returned by cin_validate because the FE logic uses position indexing to locate the elements it needs in the return).