### PR TITLE
Fix/stringify codes

### DIFF
--- a/Documentation/debug_n_transform_scripts/stringify_rule_codes.py
+++ b/Documentation/debug_n_transform_scripts/stringify_rule_codes.py
@@ -1,0 +1,31 @@
+import json
+import re
+
+
+def extract_rule_code(filepath):
+    pattern = r"rule_(\d+)\.py"
+    match = re.search(pattern, filepath)
+    if match:
+        return match.group(1)
+    else:
+        return None
+
+
+with open("files_failed.json", "r") as f:
+    filepaths = json.load(f)
+# filepath = "C:\\Users\\tambe.tabitha\\CIN-validator\\cin_validator\\rules\\cin2022_23\\rule_8940.py"
+
+for filepath in filepaths:
+    print(f"+++++++++++++++++++++++++++++++{filepath}+++++++++++++++++++++++++++++++")
+    try:
+        rule_code = extract_rule_code(filepath)
+
+        with open(filepath, "r") as f:
+            file_text = f.read()
+            file_text = file_text.replace(f"{rule_code}", f"'{rule_code}'")
+        with open(filepath, "w") as f:
+            f.write(file_text)
+            print(f"updated {rule_code} to '{rule_code}'")
+    except Exception as e:
+        print(f"Error updating {filepath}: {e}")
+        continue

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -1,5 +1,6 @@
 import datetime
 import importlib
+import json
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -144,7 +145,23 @@ def test_cmd(rule, ruleset):
             for p in module_folder.glob("*.py")
             if p.stem != "__init__"
         ]
-    pytest.main(test_files)
+
+    failed_files = []
+    for file_path in test_files:
+        result = pytest.main([file_path])
+        if result != pytest.ExitCode.OK:
+            failed_files.append(file_path)
+
+    with open("files_failed.json", "w") as f:
+        json.dump(failed_files, f)
+    # pytest.main(test_files)
+
+
+@cli.command(name="retest")
+def retest():
+    with open("files_failed.json", "r") as f:
+        filepaths = json.load(f)
+    pytest.main(filepaths)
 
 
 @cli.command(name="xmltocsv")

--- a/cin_validator/cin_validator.py
+++ b/cin_validator/cin_validator.py
@@ -282,6 +282,7 @@ class CinValidator:
         self.full_issue_df.drop_duplicates(
             ["child_id", "rule_code", "columns_affected", "row_id"], inplace=True
         )
+        self.full_issue_df.reset_index(drop=True, inplace=True)
 
     def get_rules_to_run(
         self, registry, selected_rules: Optional[list[str]] = None

--- a/cin_validator/rule_engine/__registry.py
+++ b/cin_validator/rule_engine/__registry.py
@@ -5,7 +5,7 @@ from cin_validator.rule_engine.__api import CINTable, RuleDefinition, RuleType
 
 
 def rule_definition(
-    code: int,
+    code: str,
     module: CINTable,
     rule_type: RuleType = RuleType.ERROR,
     message: Optional[str] = None,

--- a/cin_validator/rule_engine/__registry.py
+++ b/cin_validator/rule_engine/__registry.py
@@ -29,7 +29,7 @@ def rule_definition(
             return func(*args, **kwargs)
 
         definition = RuleDefinition(
-            code=code,
+            code=str(code),
             func=func,
             rule_type=rule_type,
             module=module,

--- a/cin_validator/rules/cin2022_23/rule_100.py
+++ b/cin_validator/rules/cin2022_23/rule_100.py
@@ -16,7 +16,7 @@ Year = Header.Year
 
 
 @rule_definition(
-    code=100,
+    code="100",
     module=CINTable.Header,
     message="Reference Date is incorrect",
     affected_fields=[ReferenceDate],
@@ -72,5 +72,5 @@ def test_validate():
     ]
 
     # Checks rule code and message are correct.
-    assert result.definition.code == 100
+    assert result.definition.code == "100"
     assert result.definition.message == "Reference Date is incorrect"

--- a/cin_validator/rules/cin2022_23/rule_1103.py
+++ b/cin_validator/rules/cin2022_23/rule_1103.py
@@ -22,7 +22,7 @@ CINdetailsID = CINdetails.CINdetailsID
 
 
 @rule_definition(
-    code=1103,
+    code="1103",
     module=CINTable.Assessments,
     message="The assessment start date cannot be before the referral date",
     affected_fields=[
@@ -209,7 +209,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 1103
+    assert result.definition.code == "1103"
     assert (
         result.definition.message
         == "The assessment start date cannot be before the referral date"

--- a/cin_validator/rules/cin2022_23/rule_1104.py
+++ b/cin_validator/rules/cin2022_23/rule_1104.py
@@ -15,7 +15,7 @@ CINdetailsID = CINdetails.CINdetailsID
 
 
 @rule_definition(
-    code=1104,
+    code="1104",
     module=CINTable.Section47,
     message="The date of the initial child protection conference cannot be before the referral date",
     affected_fields=[
@@ -200,7 +200,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 1104
+    assert result.definition.code == "1104"
     assert (
         result.definition.message
         == "The date of the initial child protection conference cannot be before the referral date"

--- a/cin_validator/rules/cin2022_23/rule_1105.py
+++ b/cin_validator/rules/cin2022_23/rule_1105.py
@@ -1,5 +1,5 @@
 """
-Rule number: 1105
+Rule number: '1105'
 Module: Child protection plans
 Rule details: Where present, the <CPPStartDate> (N00105) must be on or after the <CINReferralDate> (N00100)
 Rule message: The child protection plan start date cannot be before the referral date
@@ -29,7 +29,7 @@ CIN_CINdetailsID = CINDetails.CINdetailsID
 
 
 @rule_definition(
-    code=1105,
+    code="1105",
     module=CINTable.ChildProtectionPlans,
     message="The child protection plan start date cannot be before the referral date",
     affected_fields=[
@@ -208,7 +208,7 @@ def test_validate():
 
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 1105
+    assert result.definition.code == "1105"
     assert (
         result.definition.message
         == "The child protection plan start date cannot be before the referral date"

--- a/cin_validator/rules/cin2022_23/rule_1510.py
+++ b/cin_validator/rules/cin2022_23/rule_1510.py
@@ -15,7 +15,7 @@ UPN = ChildIdentifiers.UPN
 
 
 @rule_definition(
-    code=1510,
+    code="1510",
     module=CINTable.ChildIdentifiers,
     message="UPN invalid (wrong check letter at character 1)",
     affected_fields=[UPN],
@@ -107,7 +107,7 @@ def test_validate():
         IssueLocator(CINTable.ChildIdentifiers, UPN, 6),
     ]
 
-    assert result.definition.code == 1510
+    assert result.definition.code == "1510"
     assert (
         result.definition.message == "UPN invalid (wrong check letter at character 1)"
     )

--- a/cin_validator/rules/cin2022_23/rule_1520.py
+++ b/cin_validator/rules/cin2022_23/rule_1520.py
@@ -1,5 +1,5 @@
 """
-Rule number: 1520
+Rule number: '1520'
 Module: Child idenitifiers
 Rule details: Each pupil <UPN> (N00001) must be unique across all pupils in the extract. 
 Note: This rule should be evaluated at LA-level for imported data                                                                     
@@ -17,7 +17,7 @@ UPN = ChildIdentifiers.UPN
 
 
 @rule_definition(
-    code=1520,
+    code="1520",
     module=CINTable.ChildIdentifiers,
     message="More than one record with the same UPN.",
     affected_fields=[UPN],
@@ -125,5 +125,5 @@ def test_validate():
     # Check that the rule definition is what you wrote in the context above.
 
     # replace 8840 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 1520
+    assert result.definition.code == "1520"
     assert result.definition.message == "More than one record with the same UPN."

--- a/cin_validator/rules/cin2022_23/rule_1530.py
+++ b/cin_validator/rules/cin2022_23/rule_1530.py
@@ -15,7 +15,7 @@ UPN = ChildIdentifiers.UPN
 
 
 @rule_definition(
-    code=1530,
+    code="1530",
     module=CINTable.ChildIdentifiers,
     message="UPN invalid (characters 2-4 not a recognised LA code)",
     affected_fields=[UPN],
@@ -98,7 +98,6 @@ def validate(
 
 
 def test_validate():
-
     child_identifiers = pd.DataFrame(
         {
             "UPN": [
@@ -127,7 +126,7 @@ def test_validate():
         IssueLocator(CINTable.ChildIdentifiers, UPN, 6),
     ]
 
-    assert result.definition.code == 1530
+    assert result.definition.code == "1530"
     assert (
         result.definition.message
         == "UPN invalid (characters 2-4 not a recognised LA code)"

--- a/cin_validator/rules/cin2022_23/rule_1540.py
+++ b/cin_validator/rules/cin2022_23/rule_1540.py
@@ -15,7 +15,7 @@ UPN = ChildIdentifiers.UPN
 
 
 @rule_definition(
-    code=1540,
+    code="1540",
     module=CINTable.ChildIdentifiers,
     message="UPN invalid (characters 5-12 not all numeric)",
     affected_fields=[UPN],
@@ -57,5 +57,5 @@ def test_validate():
         IssueLocator(CINTable.ChildIdentifiers, UPN, 3),
     ]
 
-    assert result.definition.code == 1540
+    assert result.definition.code == "1540"
     assert result.definition.message == "UPN invalid (characters 5-12 not all numeric)"

--- a/cin_validator/rules/cin2022_23/rule_1550.py
+++ b/cin_validator/rules/cin2022_23/rule_1550.py
@@ -15,7 +15,7 @@ UPN = ChildIdentifiers.UPN
 
 
 @rule_definition(
-    code=1550,
+    code="1550",
     module=CINTable.ChildIdentifiers,
     message="UPN invalid (character 13 not a recognised value)",
     affected_fields=[UPN],
@@ -85,7 +85,7 @@ def test_validate():
         IssueLocator(CINTable.ChildIdentifiers, UPN, 2),
     ]
 
-    assert result.definition.code == 1550
+    assert result.definition.code == "1550"
     assert (
         result.definition.message == "UPN invalid (character 13 not a recognised value)"
     )

--- a/cin_validator/rules/cin2022_23/rule_2883.py
+++ b/cin_validator/rules/cin2022_23/rule_2883.py
@@ -18,9 +18,10 @@ DateOfInitialCPC = CINdetails.DateOfInitialCPC
 
 Section47 = CINTable.Section47
 
+
 # define characteristics of rule
 @rule_definition(
-    code=2883,
+    code="2883",
     # module is table that seems central to the condition.
     module=CINTable.ChildProtectionPlans,
     message="There are more child protection plans starting than initial conferences taking place",
@@ -150,6 +151,6 @@ def test_validate():
 
     issues = result.la_issues
     assert issues == (
-        2883,
+        "2883",
         "There are more child protection plans starting than initial conferences taking place",
     )

--- a/cin_validator/rules/cin2022_23/rule_2884.py
+++ b/cin_validator/rules/cin2022_23/rule_2884.py
@@ -15,7 +15,7 @@ DateOfInitialCPC = CINdetails.DateOfInitialCPC
 
 
 @rule_definition(
-    code=2884,
+    code="2884",
     module=CINTable.Section47,
     message="An initial child protection conference is recorded at both the S47 and CIN Details level and it should only be recorded in one",
     affected_fields=[
@@ -25,7 +25,6 @@ DateOfInitialCPC = CINdetails.DateOfInitialCPC
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df_47 = data_container[Section47].copy()
     df_cin = data_container[CINdetails].copy()
 
@@ -221,7 +220,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 2884
+    assert result.definition.code == "2884"
     assert (
         result.definition.message
         == "An initial child protection conference is recorded at both the S47 and CIN Details level and it should only be recorded in one"

--- a/cin_validator/rules/cin2022_23/rule_2885.py
+++ b/cin_validator/rules/cin2022_23/rule_2885.py
@@ -22,8 +22,8 @@ ReferenceDate = Header.ReferenceDate
 
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 2885
-    code=2885,
+    # write the rule code here, in place of '2885'
+    code="2885",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.ChildProtectionPlans,
@@ -606,7 +606,7 @@ def test_validate():
     assert issue_rows0.equals(expected_df0)
 
     # Confirm that the rule details were properly pushed through.
-    assert result.definition.code == 2885
+    assert result.definition.code == "2885"
     assert (
         result.definition.message
         == "Child protection plan shown as starting a different day to the initial child protection conference."

--- a/cin_validator/rules/cin2022_23/rule_2889.py
+++ b/cin_validator/rules/cin2022_23/rule_2889.py
@@ -14,7 +14,7 @@ LAchildID = CINdetails.LAchildID
 
 
 @rule_definition(
-    code=2889,
+    code="2889",
     module=CINTable.Section47,
     message="The S47 start date cannot be before the referral date.",
     affected_fields=[S47ActualStartDate, CINreferralDate],
@@ -22,7 +22,6 @@ LAchildID = CINdetails.LAchildID
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df_s47 = data_container[Section47]
     df_cin = data_container[CINdetails]
 
@@ -162,7 +161,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 2889
+    assert result.definition.code == "2889"
     assert (
         result.definition.message
         == "The S47 start date cannot be before the referral date."

--- a/cin_validator/rules/cin2022_23/rule_2990.py
+++ b/cin_validator/rules/cin2022_23/rule_2990.py
@@ -19,7 +19,7 @@ DateOfInitialCPC = CINdetails.DateOfInitialCPC
 
 # define characteristics of rule
 @rule_definition(
-    code=2990,
+    code="2990",
     module=CINTable.CINdetails,
     message="Activity is recorded against a case marked as ‘Case closed after assessment, no further action’ or 'case closed after assessment, referred to early help'.",
     affected_fields=[
@@ -382,7 +382,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 2990
+    assert result.definition.code == "2990"
     assert (
         result.definition.message
         == "Activity is recorded against a case marked as ‘Case closed after assessment, no further action’ or 'case closed after assessment, referred to early help'."

--- a/cin_validator/rules/cin2022_23/rule_4000.py
+++ b/cin_validator/rules/cin2022_23/rule_4000.py
@@ -14,7 +14,7 @@ CINdetailsID_details = CINdetails.CINdetailsID
 
 
 @rule_definition(
-    code=4000,
+    code="4000",
     module=CINTable.CINplanDates,
     message="CIN Plan details provided for a referral with no further action",
     affected_fields=[
@@ -156,7 +156,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4000
+    assert result.definition.code == "4000"
     assert (
         result.definition.message
         == "CIN Plan details provided for a referral with no further action"

--- a/cin_validator/rules/cin2022_23/rule_4001.py
+++ b/cin_validator/rules/cin2022_23/rule_4001.py
@@ -17,7 +17,7 @@ CINPlanStartDate = CINplanDates.CINPlanStartDate
 
 
 @rule_definition(
-    code=4001,
+    code="4001",
     module=CINTable.CINplanDates,
     message="A CIN Plan cannot run concurrently with a Child Protection Plan",
     affected_fields=[
@@ -199,7 +199,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4001
+    assert result.definition.code == "4001"
     assert (
         result.definition.message
         == "A CIN Plan cannot run concurrently with a Child Protection Plan"

--- a/cin_validator/rules/cin2022_23/rule_4003.py
+++ b/cin_validator/rules/cin2022_23/rule_4003.py
@@ -18,7 +18,7 @@ CPPendDate = ChildProtectionPlans.CPPendDate
 
 
 @rule_definition(
-    code=4003,
+    code="4003",
     module=CINTable.Reviews,
     message="A CPP review date is shown as being held at the same time as an open CIN Plan.",
     affected_fields=[
@@ -101,7 +101,6 @@ def validate(
 
 
 def test_validate():
-
     sample_cpp = pd.DataFrame(
         [
             {
@@ -280,7 +279,7 @@ def test_validate():
     )
 
     assert issue_rows.equals(expected_df)
-    assert result.definition.code == 4003
+    assert result.definition.code == "4003"
     assert (
         result.definition.message
         == "A CPP review date is shown as being held at the same time as an open CIN Plan."

--- a/cin_validator/rules/cin2022_23/rule_4004.py
+++ b/cin_validator/rules/cin2022_23/rule_4004.py
@@ -1,5 +1,5 @@
 """
-Rule number: 4004
+Rule number: '4004'
 Module: CIN plan dates
 Rule details: Within a <CINDetails> module, there must be only one <CINplanDates> group where the <CINPlanEnd Date> (N00690) is missing
 Rule message: This child is showing more than one open CIN Plan, i.e. with no End Date
@@ -21,7 +21,7 @@ CINdetailsID = CINplanDates.CINdetailsID
 
 
 @rule_definition(
-    code=4004,
+    code="4004",
     module=CINTable.CINplanDates,
     message="This child is showing more than one open CIN Plan, i.e. with no End Date",
     affected_fields=[CINPlanEndDate],
@@ -142,7 +142,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4004
+    assert result.definition.code == "4004"
     assert (
         result.definition.message
         == "This child is showing more than one open CIN Plan, i.e. with no End Date"

--- a/cin_validator/rules/cin2022_23/rule_4008.py
+++ b/cin_validator/rules/cin2022_23/rule_4008.py
@@ -15,7 +15,7 @@ CINPlanStartDate = CINplanDates.CINPlanStartDate
 
 
 @rule_definition(
-    code=4008,
+    code="4008",
     module=CINTable.ChildIdentifiers,
     message="CIN Plan shown as starting after the child’s Date of Death.",
     affected_fields=[
@@ -79,7 +79,6 @@ def validate(
 
 
 def test_validate():
-
     sample_ci = pd.DataFrame(
         [
             {
@@ -188,7 +187,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4008
+    assert result.definition.code == "4008"
     assert (
         result.definition.message
         == "CIN Plan shown as starting after the child’s Date of Death."

--- a/cin_validator/rules/cin2022_23/rule_4010.py
+++ b/cin_validator/rules/cin2022_23/rule_4010.py
@@ -19,7 +19,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=4010,
+    code="4010",
     module=CINTable.CINplanDates,
     message="CIN Plan start date is missing or out of data collection period",
     affected_fields=[CINPlanStartDate],
@@ -45,7 +45,6 @@ def validate(
 
 
 def test_validate():
-
     cin_start = pd.to_datetime(
         # Create some sample data such that some values pass the validation and some fail.
         [
@@ -94,7 +93,7 @@ def test_validate():
         IssueLocator(CINTable.CINplanDates, CINPlanStartDate, 8),
     ]
 
-    assert result.definition.code == 4010
+    assert result.definition.code == "4010"
     assert (
         result.definition.message
         == "CIN Plan start date is missing or out of data collection period"

--- a/cin_validator/rules/cin2022_23/rule_4011.py
+++ b/cin_validator/rules/cin2022_23/rule_4011.py
@@ -12,7 +12,7 @@ LAchildID = CINplanDates.LAchildID
 
 
 @rule_definition(
-    code=4011,
+    code="4011",
     module=CINTable.CINplanDates,
     message="CIN Plan End Date earlier than Start Date",
     affected_fields=[CINPlanEndDate, CINPlanStartDate],
@@ -118,5 +118,5 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4011
+    assert result.definition.code == "4011"
     assert result.definition.message == "CIN Plan End Date earlier than Start Date"

--- a/cin_validator/rules/cin2022_23/rule_4013.py
+++ b/cin_validator/rules/cin2022_23/rule_4013.py
@@ -18,7 +18,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=4013,
+    code="4013",
     module=CINTable.CINplanDates,
     message="CIN Plan end date must fall within the census year",
     affected_fields=[CINPlanEndDate, ReferenceDate],
@@ -75,7 +75,7 @@ def test_validate():
         IssueLocator(CINTable.CINplanDates, CINPlanEndDate, 2),
     ]
 
-    assert result.definition.code == 4013
+    assert result.definition.code == "4013"
     assert (
         result.definition.message
         == "CIN Plan end date must fall within the census year"

--- a/cin_validator/rules/cin2022_23/rule_4014.py
+++ b/cin_validator/rules/cin2022_23/rule_4014.py
@@ -16,7 +16,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=4014,
+    code="4014",
     module=CINTable.CINplanDates,
     message="CIN Plan data contains overlapping dates",
     affected_fields=[
@@ -252,5 +252,5 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4014
+    assert result.definition.code == "4014"
     assert result.definition.message == "CIN Plan data contains overlapping dates"

--- a/cin_validator/rules/cin2022_23/rule_4015.py
+++ b/cin_validator/rules/cin2022_23/rule_4015.py
@@ -15,7 +15,7 @@ CINreferralDate = CINdetails.CINreferralDate
 
 
 @rule_definition(
-    code=4015,
+    code="4015",
     module=CINTable.CINplanDates,
     message="The CIN Plan start date cannot be before the referral date",
     affected_fields=[
@@ -180,7 +180,7 @@ def test_validate():
     issue_rows.sort_values(["ROW_ID"], ignore_index=True, inplace=True)
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4015
+    assert result.definition.code == "4015"
     assert (
         result.definition.message
         == "The CIN Plan start date cannot be before the referral date"

--- a/cin_validator/rules/cin2022_23/rule_4016.py
+++ b/cin_validator/rules/cin2022_23/rule_4016.py
@@ -20,7 +20,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=4016,
+    code="4016",
     module=CINTable.CINplanDates,
     message="A CIN Plan has been reported as open at the same time as a Child Protection Plan.",
     affected_fields=[
@@ -277,7 +277,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4016
+    assert result.definition.code == "4016"
     assert (
         result.definition.message
         == "A CIN Plan has been reported as open at the same time as a Child Protection Plan."

--- a/cin_validator/rules/cin2022_23/rule_4017.py
+++ b/cin_validator/rules/cin2022_23/rule_4017.py
@@ -21,7 +21,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=4017,
+    code="4017",
     module=CINTable.CINplanDates,
     message="A CIN Plan has been reported as open at the same time as a Child Protection Plan.",
     affected_fields=[
@@ -296,7 +296,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 4017
+    assert result.definition.code == "4017"
     assert (
         result.definition.message
         == "A CIN Plan has been reported as open at the same time as a Child Protection Plan."

--- a/cin_validator/rules/cin2022_23/rule_4180.py
+++ b/cin_validator/rules/cin2022_23/rule_4180.py
@@ -16,10 +16,11 @@ from cin_validator.test_engine import run_rule
 ChildIdentifiers = CINTable.ChildIdentifiers
 GenderCurrent = ChildIdentifiers.GenderCurrent
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here, in place of 8500
-    code=4180,
+    code="4180",
     # replace ChildIdentifiers with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildIdentifiers,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -74,6 +75,6 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 4180 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 4180
+    # replace '4180' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "4180"
     assert result.definition.message == "Gender is missing"

--- a/cin_validator/rules/cin2022_23/rule_4220.py
+++ b/cin_validator/rules/cin2022_23/rule_4220.py
@@ -15,7 +15,7 @@ Ethnicity = ChildCharacteristics.Ethnicity
 
 
 @rule_definition(
-    code=4220,
+    code="4220",
     module=CINTable.ChildCharacteristics,
     message="Ethnicity is missing or invalid (see Ethnicity table)",
     affected_fields=[Ethnicity],
@@ -81,7 +81,7 @@ def test_validate():
         IssueLocator(CINTable.ChildCharacteristics, Ethnicity, 6),
     ]
 
-    assert result.definition.code == 4220
+    assert result.definition.code == "4220"
     assert (
         result.definition.message
         == "Ethnicity is missing or invalid (see Ethnicity table)"

--- a/cin_validator/rules/cin2022_23/rule_8500.py
+++ b/cin_validator/rules/cin2022_23/rule_8500.py
@@ -16,10 +16,11 @@ from cin_validator.test_engine import run_rule
 ChildIdentifiers = CINTable.ChildIdentifiers
 LAchildID = ChildIdentifiers.LAchildID
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8500
-    code=8500,
+    # write the rule code here, in place of '8500'
+    code="8500",
     # replace ChildIdentifiers with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildIdentifiers,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -65,6 +66,6 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8500 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8500
+    # replace '8500' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8500"
     assert result.definition.message == "LA Child ID missing"

--- a/cin_validator/rules/cin2022_23/rule_8510.py
+++ b/cin_validator/rules/cin2022_23/rule_8510.py
@@ -1,5 +1,5 @@
 """
-Rule number: 8510
+Rule number: '8510'
 Module: Child idenitifiers
 Rule details: Each <LAchildID> (N00097) must be unique across all children within the same LA return. 
 
@@ -25,7 +25,7 @@ LAchildID = ChildIdentifiers.LAchildID
 
 
 @rule_definition(
-    code=8510,
+    code="8510",
     module=CINTable.ChildIdentifiers,
     message="More than one child record with the same LA Child ID",
     affected_fields=[LAchildID],
@@ -55,7 +55,7 @@ def test_validate():
         IssueLocator(CINTable.ChildIdentifiers, LAchildID, 1),
     ]
 
-    assert result.definition.code == 8510
+    assert result.definition.code == "8510"
     assert (
         result.definition.message
         == "More than one child record with the same LA Child ID"

--- a/cin_validator/rules/cin2022_23/rule_8520.py
+++ b/cin_validator/rules/cin2022_23/rule_8520.py
@@ -18,7 +18,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=8520,
+    code="8520",
     module=CINTable.ChildIdentifiers,
     message="Date of Birth is after data collection period (must be on or before the end of the census period)",
     affected_fields=[PersonBirthDate, ReferenceDate],
@@ -26,7 +26,6 @@ ReferenceDate = Header.ReferenceDate
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df = data_container[ChildIdentifiers]
     df_ref = data_container[Header]
 
@@ -69,7 +68,7 @@ def test_validate():
         IssueLocator(CINTable.ChildIdentifiers, PersonBirthDate, 3),
     ]
 
-    assert result.definition.code == 8520
+    assert result.definition.code == "8520"
     assert (
         result.definition.message
         == "Date of Birth is after data collection period (must be on or before the end of the census period)"

--- a/cin_validator/rules/cin2022_23/rule_8540.py
+++ b/cin_validator/rules/cin2022_23/rule_8540.py
@@ -16,7 +16,7 @@ Disability = Disabilities.Disability
 
 
 @rule_definition(
-    code=8540,
+    code="8540",
     module=CINTable.ChildCharacteristics,
     message="Child’s disability is missing or invalid (see Disability table)",
     affected_fields=[Disability, PersonBirthDate, ReferralNFA],
@@ -24,7 +24,6 @@ Disability = Disabilities.Disability
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df_dis = data_container[Disabilities].copy()
     df_ci = data_container[ChildIdentifiers].copy()
     df_cin = data_container[CINdetails].copy()
@@ -221,7 +220,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8540
+    assert result.definition.code == "8540"
     assert (
         result.definition.message
         == "Child’s disability is missing or invalid (see Disability table)"

--- a/cin_validator/rules/cin2022_23/rule_8565.py
+++ b/cin_validator/rules/cin2022_23/rule_8565.py
@@ -1,5 +1,5 @@
 """
-Rule number: 8565
+Rule number: '8565'
 Module: CIN Details
 Rule details: If <CINclosureDate> (N00102) is present then it must be on or after all of the following dates that are present:
     <AssessmentActualStartDate> (N00159)
@@ -51,7 +51,7 @@ CINPlanEndDate = CINplanDates.CINPlanEndDate
 
 
 @rule_definition(
-    code=8565,
+    code="8565",
     module=CINTable.ChildProtectionPlans,
     message="Activity shown after a case has been closed",
     affected_fields=[
@@ -502,5 +502,5 @@ def test_validate():
         ]
     )
 
-    assert result.definition.code == 8565
+    assert result.definition.code == "8565"
     assert result.definition.message == "Activity shown after a case has been closed"

--- a/cin_validator/rules/cin2022_23/rule_8568.py
+++ b/cin_validator/rules/cin2022_23/rule_8568.py
@@ -15,7 +15,7 @@ ReferralNFA = CINdetails.ReferralNFA
 
 
 @rule_definition(
-    code=8568,
+    code="8568",
     module=CINTable.CINdetails,
     message="RNFA flag is missing or invalid",
     affected_fields=[ReferralNFA],
@@ -35,7 +35,6 @@ def validate(
 
 
 def test_validate():
-
     RNFA = [1, 0, 2, pd.NA, "true", "Woof", "Meow"]
 
     fake_dataframe = pd.DataFrame({"ReferralNFA": RNFA})
@@ -53,5 +52,5 @@ def test_validate():
         IssueLocator(CINTable.CINdetails, ReferralNFA, 6),
     ]
 
-    assert result.definition.code == 8568
+    assert result.definition.code == "8568"
     assert result.definition.message == "RNFA flag is missing or invalid"

--- a/cin_validator/rules/cin2022_23/rule_8590.py
+++ b/cin_validator/rules/cin2022_23/rule_8590.py
@@ -12,7 +12,7 @@ LAchildID = ChildIdentifiers.LAchildID
 
 
 @rule_definition(
-    code=8590,
+    code="8590",
     module=CINTable.ChildIdentifiers,
     message="Child does not have a recorded CIN episode.",
     affected_fields=[LAchildID],
@@ -120,5 +120,5 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8590
+    assert result.definition.code == "8590"
     assert result.definition.message == "Child does not have a recorded CIN episode."

--- a/cin_validator/rules/cin2022_23/rule_8600.py
+++ b/cin_validator/rules/cin2022_23/rule_8600.py
@@ -18,7 +18,7 @@ ReferenceDate = Header.ReferenceDate
 
 
 @rule_definition(
-    code=8600,
+    code="8600",
     module=CINTable.CINdetails,
     message="Child referral date missing or after data collection period",
     affected_fields=[CINreferralDate],
@@ -26,7 +26,6 @@ ReferenceDate = Header.ReferenceDate
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df = data_container[Cindetails]
     df_ref = data_container[Header]
 
@@ -81,7 +80,7 @@ def test_validate():
         IssueLocator(CINTable.CINdetails, CINreferralDate, 8),
     ]
 
-    assert result.definition.code == 8600
+    assert result.definition.code == "8600"
     assert (
         result.definition.message
         == "Child referral date missing or after data collection period"

--- a/cin_validator/rules/cin2022_23/rule_8606.py
+++ b/cin_validator/rules/cin2022_23/rule_8606.py
@@ -1,5 +1,5 @@
 """
-Rule number: 8606
+Rule number: '8606'
 Module: CIN details
 Rule details: <CINreferralDate> (N00100) cannot be more than 280 days before <PersonBirthDate> (N00066) or <ExpectedPersonBirthDate> (N00098)
 Rule message: Child referral date is more than 40 weeks before DOB or expected DOB
@@ -25,7 +25,7 @@ LAchildID = CINdetails.LAchildID
 
 
 @rule_definition(
-    code=8606,
+    code="8606",
     module=CINTable.CINdetails,
     message="Child referral date is more than 40 weeks before DOB or expected DOB",
     affected_fields=[
@@ -37,7 +37,6 @@ LAchildID = CINdetails.LAchildID
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df_CINDetails = data_container[CINdetails].copy()
     df_ChildIdentifiers = data_container[ChildIdentifiers].copy()
 
@@ -204,7 +203,7 @@ def test_validate():
 
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8606
+    assert result.definition.code == "8606"
     assert (
         result.definition.message
         == "Child referral date is more than 40 weeks before DOB or expected DOB"

--- a/cin_validator/rules/cin2022_23/rule_8608.py
+++ b/cin_validator/rules/cin2022_23/rule_8608.py
@@ -12,7 +12,7 @@ AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 
 
 @rule_definition(
-    code=8608,
+    code="8608",
     module=CINTable.Assessments,
     message="Assessment Start Date cannot be later than its End Date",
     affected_fields=[AssessmentActualStartDate, AssessmentAuthorisationDate],
@@ -129,7 +129,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8608
+    assert result.definition.code == "8608"
     assert (
         result.definition.message
         == "Assessment Start Date cannot be later than its End Date"

--- a/cin_validator/rules/cin2022_23/rule_8610.py
+++ b/cin_validator/rules/cin2022_23/rule_8610.py
@@ -13,7 +13,7 @@ CINdetailsID = CINdetails.CINdetailsID
 
 
 @rule_definition(
-    code=8610,
+    code="8610",
     module=CINTable.CINdetails,
     message="Primary Need code is missing for a referral which led to further action.",
     affected_fields=[ReferralNFA, PrimaryNeedCode],
@@ -105,7 +105,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8610
+    assert result.definition.code == "8610"
     assert (
         result.definition.message
         == "Primary Need code is missing for a referral which led to further action."

--- a/cin_validator/rules/cin2022_23/rule_8614.py
+++ b/cin_validator/rules/cin2022_23/rule_8614.py
@@ -12,7 +12,7 @@ LAchildID = Assessments.LAchildID
 
 
 @rule_definition(
-    code=8614,
+    code="8614",
     module=CINTable.Assessments,
     message="Parental or child factors at assessment should only be present for a completed assessment.",
     affected_fields=[AssessmentAuthorisationDate, AssessmentFactors],
@@ -52,7 +52,6 @@ def validate(
 
 
 def test_validate():
-
     fake_data = pd.DataFrame(
         [
             {
@@ -124,7 +123,7 @@ def test_validate():
     )
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8614
+    assert result.definition.code == "8614"
     assert (
         result.definition.message
         == "Parental or child factors at assessment should only be present for a completed assessment."

--- a/cin_validator/rules/cin2022_23/rule_8620.py
+++ b/cin_validator/rules/cin2022_23/rule_8620.py
@@ -21,7 +21,7 @@ ReferenceDate = Header.ReferenceDate
 
 # define characteristics of rule
 @rule_definition(
-    code=8620,
+    code="8620",
     module=CINTable.CINdetails,
     message="CIN Closure Date present and does not fall within the Census year",
     affected_fields=[CINclosureDate],
@@ -95,8 +95,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8620 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8620
+    # replace '8620' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8620"
     assert (
         result.definition.message
         == "CIN Closure Date present and does not fall within the Census year"

--- a/cin_validator/rules/cin2022_23/rule_8640.py
+++ b/cin_validator/rules/cin2022_23/rule_8640.py
@@ -13,9 +13,10 @@ from cin_validator.test_engine import run_rule
 CINdetails = CINTable.CINdetails
 ReasonForClosure = CINdetails.ReasonForClosure
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8640,
+    code="8640",
     module=CINTable.CINdetails,
     message="CIN Reason for closure code invalid (see Reason for Closure table in CIN Census code set)",
     affected_fields=[ReasonForClosure],
@@ -68,7 +69,7 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    assert result.definition.code == 8640
+    assert result.definition.code == "8640"
     assert (
         result.definition.message
         == "CIN Reason for closure code invalid (see Reason for Closure table in CIN Census code set)"

--- a/cin_validator/rules/cin2022_23/rule_8650.py
+++ b/cin_validator/rules/cin2022_23/rule_8650.py
@@ -13,9 +13,10 @@ from cin_validator.test_engine import run_rule
 CINdetails = CINTable.CINdetails
 PrimaryNeedCode = CINdetails.PrimaryNeedCode
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8650,
+    code="8650",
     module=CINTable.CINdetails,
     message="Primary Need Code invalid (see Primary Need table in CIN census code set)",
     affected_fields=[PrimaryNeedCode],
@@ -39,7 +40,6 @@ def validate(
 
 
 def test_validate():
-
     pri_need = ["N1", "N8", "AA", pd.NA, "N6", "BB", "N9"]
 
     fake_dataframe = pd.DataFrame({"PrimaryNeedCode": pri_need})
@@ -55,7 +55,7 @@ def test_validate():
         IssueLocator(CINTable.CINdetails, PrimaryNeedCode, 5),
     ]
 
-    assert result.definition.code == 8650
+    assert result.definition.code == "8650"
     assert (
         result.definition.message
         == "Primary Need Code invalid (see Primary Need table in CIN census code set)"

--- a/cin_validator/rules/cin2022_23/rule_8696.py
+++ b/cin_validator/rules/cin2022_23/rule_8696.py
@@ -18,9 +18,10 @@ Header = CINTable.Header
 AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8696,
+    code="8696",
     module=CINTable.Assessments,
     message="Assessment end date must fall within the census year",
     affected_fields=[AssessmentAuthorisationDate, ReferenceDate],
@@ -28,7 +29,6 @@ ReferenceDate = Header.ReferenceDate
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df = data_container[Assessments]
     df_ref = data_container[Header]
 
@@ -84,7 +84,7 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    assert result.definition.code == 8696
+    assert result.definition.code == "8696"
     assert (
         result.definition.message
         == "Assessment end date must fall within the census year"

--- a/cin_validator/rules/cin2022_23/rule_8715.py
+++ b/cin_validator/rules/cin2022_23/rule_8715.py
@@ -18,9 +18,10 @@ DateOfInitialCPC = Section47.DateOfInitialCPC
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8715,
+    code="8715",
     module=CINTable.Section47,
     message="Date of Initial Child Protection Conference must fall within the census year",
     affected_fields=[DateOfInitialCPC, ReferenceDate],
@@ -93,8 +94,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8715 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8715
+    # replace '8715' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8715"
     assert (
         result.definition.message
         == "Date of Initial Child Protection Conference must fall within the census year"

--- a/cin_validator/rules/cin2022_23/rule_8720.py
+++ b/cin_validator/rules/cin2022_23/rule_8720.py
@@ -18,10 +18,11 @@ Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 CPPID = ChildProtectionPlans.CPPID
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8720
-    code=8720,
+    # write the rule code here, in place of '8720'
+    code="8720",
     # replace ChildIdentifiers with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildProtectionPlans,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -101,8 +102,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8720 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8720
+    # replace '8720' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8720"
     assert (
         result.definition.message
         == "Child Protection Plan Start Date missing or out of data collection period"

--- a/cin_validator/rules/cin2022_23/rule_8730.py
+++ b/cin_validator/rules/cin2022_23/rule_8730.py
@@ -15,9 +15,10 @@ from cin_validator.test_engine import run_rule
 ChildProtectionPlans = CINTable.ChildProtectionPlans
 NumberOfPreviousCPP = ChildProtectionPlans.NumberOfPreviousCPP
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8730,
+    code="8730",
     module=CINTable.ChildProtectionPlans,
     message="Total Number of previous Child Protection Plans missing",
     affected_fields=[NumberOfPreviousCPP],
@@ -66,8 +67,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8730 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8730
+    # replace '8730' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8730"
     assert (
         result.definition.message
         == "Total Number of previous Child Protection Plans missing"

--- a/cin_validator/rules/cin2022_23/rule_8736.py
+++ b/cin_validator/rules/cin2022_23/rule_8736.py
@@ -17,9 +17,10 @@ LAchildID = Assessments.LAchildID
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8736,
+    code="8736",
     module=CINTable.Assessments,
     message="For an Assessment that has not been completed, the start date must fall within the census year",
     affected_fields=[AssessmentAuthorisationDate, AssessmentActualStartDate],
@@ -190,8 +191,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8736 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8736
+    # replace '8736' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8736"
     assert (
         result.definition.message
         == "For an Assessment that has not been completed, the start date must fall within the census year"

--- a/cin_validator/rules/cin2022_23/rule_8740.py
+++ b/cin_validator/rules/cin2022_23/rule_8740.py
@@ -17,9 +17,10 @@ ICPCnotRequired = Section47.ICPCnotRequired
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8740,
+    code="8740",
     module=CINTable.Section47,
     message="For a Section 47 Enquiry that has not held the Initial Child Protection Conference by the end of the census year, the start date must fall within the census year",
     affected_fields=[S47ActualStartDate, DateOfInitialCPC, ICPCnotRequired],
@@ -175,8 +176,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8740 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8740
+    # replace '8740' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8740"
     assert (
         result.definition.message
         == "For a Section 47 Enquiry that has not held the Initial Child Protection Conference by the end of the census year, the start date must fall within the census year"

--- a/cin_validator/rules/cin2022_23/rule_8750.py
+++ b/cin_validator/rules/cin2022_23/rule_8750.py
@@ -13,10 +13,11 @@ PersonBirthDate = ChildIdentifiers.PersonBirthDate
 ExpectedPersonBirthDate = ChildIdentifiers.ExpectedPersonBirthDate
 GenderCurrent = ChildIdentifiers.GenderCurrent
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here, in place of 8750
-    code=8750,
+    code="8750",
     # replace ChildIdentifiers with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildIdentifiers,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -172,5 +173,5 @@ def test_validate():
     # Check that the rule definition is what you wrote in the context above.
 
     # replace 8750 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8750
+    assert result.definition.code == "8750"
     assert result.definition.message == "Gender must equal 0 for an unborn child"

--- a/cin_validator/rules/cin2022_23/rule_8772.py
+++ b/cin_validator/rules/cin2022_23/rule_8772.py
@@ -17,7 +17,7 @@ ReferralNFA = CINdetails.ReferralNFA
 
 
 @rule_definition(
-    code=8772,
+    code="8772",
     module=CINTable.ChildIdentifiers,
     message="UPN unknown reason is UN7 (Referral with no further action) but at least one CIN details is a referral going on to further action",
     affected_fields=[
@@ -203,8 +203,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8772 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8772
+    # replace '8772' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8772"
     assert (
         result.definition.message
         == "UPN unknown reason is UN7 (Referral with no further action) but at least one CIN details is a referral going on to further action"

--- a/cin_validator/rules/cin2022_23/rule_8790.py
+++ b/cin_validator/rules/cin2022_23/rule_8790.py
@@ -13,9 +13,10 @@ from cin_validator.test_engine import run_rule
 Disabilities = CINTable.Disabilities
 Disability = Disabilities.Disability
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8790,
+    code="8790",
     module=CINTable.Disabilities,
     message="Disability information includes both None and other values",
     affected_fields=[Disability],
@@ -64,7 +65,7 @@ def test_validate():
         IssueLocator(CINTable.Disabilities, Disability, 6),
     ]
 
-    assert result.definition.code == 8790
+    assert result.definition.code == "8790"
     assert (
         result.definition.message
         == "Disability information includes both None and other values"

--- a/cin_validator/rules/cin2022_23/rule_8794.py
+++ b/cin_validator/rules/cin2022_23/rule_8794.py
@@ -13,9 +13,10 @@ from cin_validator.test_engine import run_rule
 Disabilities = CINTable.Disabilities
 Disability = Disabilities.Disability
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8794,
+    code="8794",
     module=CINTable.Disabilities,
     message="Child has two or more disabilities with the same code",
     affected_fields=[Disability],
@@ -83,7 +84,7 @@ def test_validate():
         IssueLocator(CINTable.Disabilities, Disability, 12),
     ]
 
-    assert result.definition.code == 8794
+    assert result.definition.code == "8794"
     assert (
         result.definition.message
         == "Child has two or more disabilities with the same code"

--- a/cin_validator/rules/cin2022_23/rule_8805.py
+++ b/cin_validator/rules/cin2022_23/rule_8805.py
@@ -12,10 +12,11 @@ CINclosureDate = CINDetails.CINclosureDate
 ReasonForClosure = CINDetails.ReasonForClosure
 LAchildID = CINDetails.LAchildID
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8805
-    code=8805,
+    # write the rule code here, in place of '8805'
+    code="8805",
     module=CINTable.CINdetails,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
     message="A CIN case cannot have a CIN closure date without a Reason for Closure",
@@ -152,8 +153,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8805 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8805
+    # replace '8805' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8805"
     assert (
         result.definition.message
         == "A CIN case cannot have a CIN closure date without a Reason for Closure"

--- a/cin_validator/rules/cin2022_23/rule_8810.py
+++ b/cin_validator/rules/cin2022_23/rule_8810.py
@@ -13,9 +13,10 @@ CINclosureDate = CINdetails.CINclosureDate
 CINdetailsID = CINdetails.CINdetailsID
 LAchildID = CINdetails.LAchildID
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8810,
+    code="8810",
     module=CINTable.CINdetails,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
     message="A CIN case cannot have a Reason for Closure without a CIN Closure Date",
@@ -150,8 +151,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8810 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8810
+    # replace '8810' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8810"
     assert (
         result.definition.message
         == "A CIN case cannot have a Reason for Closure without a CIN Closure Date"

--- a/cin_validator/rules/cin2022_23/rule_8815.py
+++ b/cin_validator/rules/cin2022_23/rule_8815.py
@@ -16,10 +16,11 @@ ReferralNFA = CINdetails.ReferralNFA
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8815,
+    code="8815",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.CINdetails,
@@ -232,8 +233,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8815 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8815
+    # replace '8815' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8815"
     assert (
         result.definition.message
         == "More than one open CIN Details episode (a module with no CIN Closure Date) has been provided for this child and case is not a referral with no further action."

--- a/cin_validator/rules/cin2022_23/rule_8816.py
+++ b/cin_validator/rules/cin2022_23/rule_8816.py
@@ -18,7 +18,7 @@ CINclosureDate = CINdetails.CINclosureDate
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8816,
+    code="8816",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.CINdetails,
@@ -257,8 +257,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8816 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8816
+    # replace '8816' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8816"
     assert (
         result.definition.message
         == "An open CIN episode is shown and case is not a referral with no further action, but it is not the latest episode."

--- a/cin_validator/rules/cin2022_23/rule_8820.py
+++ b/cin_validator/rules/cin2022_23/rule_8820.py
@@ -22,7 +22,7 @@ ReferenceDate = Header.ReferenceDate
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8820,
+    code="8820",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.CINdetails,
@@ -317,8 +317,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8820 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8820
+    # replace '8820' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8820"
     assert (
         result.definition.message
         == "The dates on the CIN episodes for this child overlap"

--- a/cin_validator/rules/cin2022_23/rule_8831.py
+++ b/cin_validator/rules/cin2022_23/rule_8831.py
@@ -20,10 +20,11 @@ DateOfInitialCPC = CINdetails.DateOfInitialCPC
 LAchildID = CINdetails.LAchildID
 CINdetailsID = CINdetails.CINdetailsID
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8831
-    code=8831,
+    # write the rule code here, in place of '8831'
+    code="8831",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.CINdetails,
@@ -352,8 +353,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8831 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8831
+    # replace '8831' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8831"
     assert (
         result.definition.message
         == "Activity is recorded against a case marked as a referral with no further action"

--- a/cin_validator/rules/cin2022_23/rule_8832.py
+++ b/cin_validator/rules/cin2022_23/rule_8832.py
@@ -16,10 +16,11 @@ ReferralNFA = CINdetails.ReferralNFA
 LAchildID_details = CINdetails.LAchildID
 CINdetailsID_details = CINdetails.CINdetailsID
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8832,
+    code="8832",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.ChildProtectionPlans,
@@ -214,8 +215,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8832 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8832
+    # replace '8832' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8832"
     assert (
         result.definition.message
         == "Child Protection details provided for a referral with no further action."

--- a/cin_validator/rules/cin2022_23/rule_8839.py
+++ b/cin_validator/rules/cin2022_23/rule_8839.py
@@ -16,7 +16,7 @@ ICPCnotRequired = Section47.ICPCnotRequired
 
 # define characteristics of rule
 @rule_definition(
-    code=8839,
+    code="8839",
     module=CINTable.Section47,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
     message="Within one CINDetails group there are 2 or more open S47 Assessments",
@@ -216,8 +216,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8839 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8839
+    # replace '8839' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8839"
     assert (
         result.definition.message
         == "Within one CINDetails group there are 2 or more open S47 Assessments"

--- a/cin_validator/rules/cin2022_23/rule_8840.py
+++ b/cin_validator/rules/cin2022_23/rule_8840.py
@@ -13,10 +13,11 @@ LAchildID = ChildProtectionPlans.LAchildID
 CPPstartDate = ChildProtectionPlans.CPPstartDate
 CPPendDate = ChildProtectionPlans.CPPendDate
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8840
-    code=8840,
+    # write the rule code here, in place of '8840'
+    code="8840",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildProtectionPlans,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -153,8 +154,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8840 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8840
+    # replace '8840' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8840"
     assert (
         result.definition.message
         == "Child Protection Plan cannot start and end on the same day"

--- a/cin_validator/rules/cin2022_23/rule_8841.py
+++ b/cin_validator/rules/cin2022_23/rule_8841.py
@@ -18,10 +18,11 @@ CPPreviewDate = Reviews.CPPreviewDate
 CPPID_reviews = Reviews.CPPID
 CINdetailsReviews = Reviews.CINdetailsID
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8841,
+    code="8841",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.ChildProtectionPlans,
@@ -283,8 +284,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8841 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8841
+    # replace '8841' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8841"
     assert (
         result.definition.message
         == "The review date cannot be on the same day or before the Child protection Plan start date."

--- a/cin_validator/rules/cin2022_23/rule_8866.py
+++ b/cin_validator/rules/cin2022_23/rule_8866.py
@@ -12,10 +12,11 @@ LAchildID = CINdetails.LAchildID
 CINreferralDate = CINdetails.CINreferralDate
 ReferralSource = CINdetails.ReferralSource
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8866
-    code=8866,
+    # write the rule code here, in place of '8866'
+    code="8866",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.CINdetails,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -167,7 +168,7 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    assert result.definition.code == 8866
+    assert result.definition.code == "8866"
     assert (
         result.definition.message == "Source of Referral is missing or an invalid code"
     )

--- a/cin_validator/rules/cin2022_23/rule_8867.py
+++ b/cin_validator/rules/cin2022_23/rule_8867.py
@@ -20,7 +20,7 @@ CINdetailsAssID = Assessments.CINdetailsID
 
 # define characteristics of rule
 @rule_definition(
-    code=8867,
+    code="8867",
     module=CINTable.CINdetails,
     message="CIN episode is shown as closed, however Assessment is not shown as completed",
     affected_fields=[
@@ -244,7 +244,7 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    assert result.definition.code == 8867
+    assert result.definition.code == "8867"
     assert (
         result.definition.message
         == "CIN episode is shown as closed, however Assessment is not shown as completed"

--- a/cin_validator/rules/cin2022_23/rule_8868.py
+++ b/cin_validator/rules/cin2022_23/rule_8868.py
@@ -16,9 +16,10 @@ CINdetailsID = CINdetails.CINdetailsID
 DateOfInitialCPC = Section47.DateOfInitialCPC
 ICPCnotRequired = Section47.ICPCnotRequired
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8868,
+    code="8868",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.CINdetails,
@@ -267,8 +268,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8868 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8868
+    # replace '8868' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8868"
     assert (
         result.definition.message
         == "CIN episode is shown as closed, however Section 47 enquiry is not shown as completed by ICPC date or ICPC not required flag"

--- a/cin_validator/rules/cin2022_23/rule_8869.py
+++ b/cin_validator/rules/cin2022_23/rule_8869.py
@@ -22,7 +22,7 @@ AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8869,
+    code="8869",
     # replace Assessments with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.Assessments,
@@ -123,7 +123,7 @@ def test_validate():
         IssueLocator(CINTable.Assessments, AssessmentFactors, 6),
     ]
 
-    assert result.definition.code == 8869
+    assert result.definition.code == "8869"
     assert (
         result.definition.message
         == "The assessment factors code “21” cannot be used in conjunction with any other assessment factors."

--- a/cin_validator/rules/cin2022_23/rule_8875.py
+++ b/cin_validator/rules/cin2022_23/rule_8875.py
@@ -1,5 +1,5 @@
 """
-Rule number: 8875
+Rule number: '8875'
 Module: Section 47
 Rule details: Where present, the <DateOfInitialCPC> (N00110) must not be a Saturday, Sunday
 Rule message: The Date of Initial Child Protection Conference cannot be a weekend
@@ -22,9 +22,10 @@ from cin_validator.test_engine import run_rule
 Section47 = CINTable.Section47
 DateOfInitialCPC = Section47.DateOfInitialCPC
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8875,
+    code="8875",
     module=CINTable.Section47,
     message="The Date of Initial Child Protection Conference cannot be a weekend",
     affected_fields=[DateOfInitialCPC],
@@ -72,7 +73,7 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    assert result.definition.code == 8875
+    assert result.definition.code == "8875"
     assert (
         result.definition.message
         == "The Date of Initial Child Protection Conference cannot be a weekend"

--- a/cin_validator/rules/cin2022_23/rule_8890.py
+++ b/cin_validator/rules/cin2022_23/rule_8890.py
@@ -18,10 +18,11 @@ ICPCnotRequired = Section47.ICPCnotRequired
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8890,
+    code="8890",
     # replace CINdetails with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.CINdetails,
@@ -308,8 +309,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8890 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8890
+    # replace '8890' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8890"
     assert (
         result.definition.message
         == "A Section 47 enquiry is shown as starting when there is another Section 47 Enquiry ongoing"

--- a/cin_validator/rules/cin2022_23/rule_8896.py
+++ b/cin_validator/rules/cin2022_23/rule_8896.py
@@ -12,10 +12,11 @@ AssessmentAuthorisationDate = Assessments.AssessmentAuthorisationDate
 LAchildID = Assessments.LAchildID
 CINdetailsID = Assessments.CINdetailsID
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8896
-    code=8896,
+    # write the rule code here, in place of '8896'
+    code="8896",
     # replace Assessments with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.Assessments,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -174,7 +175,7 @@ def test_validate():
     # Check that the rule definition is what you wrote in the context above.
 
     # replace 8925 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8896
+    assert result.definition.code == "8896"
     assert (
         result.definition.message
         == "Within one CINDetails group there are 2 or more open Assessments groups"

--- a/cin_validator/rules/cin2022_23/rule_8898.py
+++ b/cin_validator/rules/cin2022_23/rule_8898.py
@@ -13,10 +13,11 @@ AssessmentFactors = Assessments.AssessmentFactors
 LAchildID = Assessments.LAchildID
 CINdetailsID = Assessments.CINdetailsID
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8898
-    code=8898,
+    # write the rule code here, in place of '8898'
+    code="8898",
     # replace Assessments with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.Assessments,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -27,7 +28,6 @@ CINdetailsID = Assessments.CINdetailsID
 def validate(
     data_container: Mapping[CINTable, pd.DataFrame], rule_context: RuleContext
 ):
-
     df = data_container[Assessments]
     df.index.name = "ROW_ID"
     df.reset_index(inplace=True)
@@ -143,8 +143,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8898 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8898
+    # replace '8898' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8898"
     assert (
         result.definition.message
         == " The assessment has more than one parental or child factors with the same code"

--- a/cin_validator/rules/cin2022_23/rule_8905.py
+++ b/cin_validator/rules/cin2022_23/rule_8905.py
@@ -13,9 +13,10 @@ from cin_validator.test_engine import run_rule
 ChildProtectionPlans = CINTable.ChildProtectionPlans
 InitialCategoryOfAbuse = ChildProtectionPlans.InitialCategoryOfAbuse
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8905,
+    code="8905",
     module=CINTable.ChildProtectionPlans,
     message="Initial Category of Abuse code missing or invalid (see Category of Abuse table in CIN Census code set)",
     affected_fields=[InitialCategoryOfAbuse],
@@ -43,7 +44,6 @@ def validate(
 
 
 def test_validate():
-
     fake_cats = ["NEG", "AAA", "PHY", pd.NA, "BBB", "EMO", "MUL"]
 
     fake_dataframe = pd.DataFrame({InitialCategoryOfAbuse: fake_cats})
@@ -60,7 +60,7 @@ def test_validate():
         IssueLocator(CINTable.ChildProtectionPlans, InitialCategoryOfAbuse, 4),
     ]
 
-    assert result.definition.code == 8905
+    assert result.definition.code == "8905"
     assert (
         result.definition.message
         == "Initial Category of Abuse code missing or invalid (see Category of Abuse table in CIN Census code set)"

--- a/cin_validator/rules/cin2022_23/rule_8910.py
+++ b/cin_validator/rules/cin2022_23/rule_8910.py
@@ -13,9 +13,10 @@ from cin_validator.test_engine import run_rule
 ChildProtectionPlans = CINTable.ChildProtectionPlans
 LatestCategoryOfAbuse = ChildProtectionPlans.LatestCategoryOfAbuse
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8910,
+    code="8910",
     module=CINTable.ChildProtectionPlans,
     message="Latest Category of Abuse code missing or invalid (see Category of Abuse table in CIN Census code set)",
     affected_fields=[LatestCategoryOfAbuse],
@@ -42,7 +43,6 @@ def validate(
 
 
 def test_validate():
-
     fake_cats = ["NEG", "AAA", "BBB", pd.NA, "PHY", "EMO", "MUL"]
 
     fake_dataframe = pd.DataFrame({"LatestCategoryOfAbuse": fake_cats})
@@ -59,7 +59,7 @@ def test_validate():
         IssueLocator(CINTable.ChildProtectionPlans, LatestCategoryOfAbuse, 3),
     ]
 
-    assert result.definition.code == 8910
+    assert result.definition.code == "8910"
     assert (
         result.definition.message
         == "Latest Category of Abuse code missing or invalid (see Category of Abuse table in CIN Census code set)"

--- a/cin_validator/rules/cin2022_23/rule_8915.py
+++ b/cin_validator/rules/cin2022_23/rule_8915.py
@@ -1,5 +1,5 @@
 """
-Rule number: 8915
+Rule number: '8915'
 Module: Child protection plans
 Rule details: If <PersonDeathDate> (N00108) is present, then <CPPstartDate> (N00105) must be on or before <PersonDeathDate> (N00108)
 Rule message: Child Protection Plan shown as starting after the child’s Date of Death
@@ -25,7 +25,7 @@ CI_LAID = ChildIdentifiers.LAchildID
 
 # define characteristics of rule
 @rule_definition(
-    code=8915,
+    code="8915",
     module=CINTable.ChildProtectionPlans,
     message="Child Protection Plan shown as starting after the child’s Date of Death",
     affected_fields=[
@@ -204,7 +204,7 @@ def test_validate():
 
     assert issue_rows.equals(expected_df)
 
-    assert result.definition.code == 8915
+    assert result.definition.code == "8915"
     assert (
         result.definition.message
         == "Child Protection Plan shown as starting after the child’s Date of Death"

--- a/cin_validator/rules/cin2022_23/rule_8920.py
+++ b/cin_validator/rules/cin2022_23/rule_8920.py
@@ -15,9 +15,10 @@ ChildIdentifiers = CINTable.ChildIdentifiers
 PersonDeathDate = ChildIdentifiers.PersonDeathDate
 LAchildID = ChildIdentifiers.LAchildID
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8920,
+    code="8920",
     module=CINTable.ChildProtectionPlans,
     message="Child Protection Plan cannot end after the child’s Date of Death",
     affected_fields=[
@@ -249,7 +250,7 @@ def test_validate():
     # Check that the rule definition is what you wrote in the context above.
 
     # replace 2885 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8920
+    assert result.definition.code == "8920"
     assert (
         result.definition.message
         == "Child Protection Plan cannot end after the child’s Date of Death"

--- a/cin_validator/rules/cin2022_23/rule_8925.py
+++ b/cin_validator/rules/cin2022_23/rule_8925.py
@@ -12,9 +12,10 @@ CPPendDate = ChildProtectionPlans.CPPendDate
 CPPstartDate = ChildProtectionPlans.CPPstartDate
 LAchildID = ChildProtectionPlans.LAchildID
 
+
 # define characteristics of rule
 @rule_definition(
-    code=8925,
+    code="8925",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildProtectionPlans,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -160,8 +161,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8925 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8925
+    # replace '8925' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8925"
     assert (
         result.definition.message
         == "Child Protection Plan End Date earlier than Start Date"

--- a/cin_validator/rules/cin2022_23/rule_8930.py
+++ b/cin_validator/rules/cin2022_23/rule_8930.py
@@ -18,10 +18,11 @@ CPPendDate = ChildProtectionPlans.CPPendDate
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8930
-    code=8930,
+    # write the rule code here, in place of '8930'
+    code="8930",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildProtectionPlans,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -98,8 +99,8 @@ def test_validate():
 
     # Check that the rule definition is what you wrote in the context above.
 
-    # replace 8930 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8930
+    # replace '8930' with the rule code and put the appropriate message in its place too.
+    assert result.definition.code == "8930"
     assert (
         result.definition.message
         == "Child Protection Plan End Date must fall within the census year"

--- a/cin_validator/rules/cin2022_23/rule_8935.py
+++ b/cin_validator/rules/cin2022_23/rule_8935.py
@@ -14,8 +14,8 @@ CPPID = ChildProtectionPlans.CPPID
 
 # define characteristics of rule
 @rule_definition(
-    # write the rule code here, in place of 8935
-    code=8935,
+    # write the rule code here, in place of '8935'
+    code="8935",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     module=CINTable.ChildProtectionPlans,
     # replace the message with the corresponding value for this rule, gotten from the excel sheet.
@@ -170,7 +170,7 @@ def test_validate():
     # Check that the rule definition is what you wrote in the context above.
 
     # replace 8925 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8935
+    assert result.definition.code == "8935"
     assert (
         result.definition.message
         == "This child is showing more than one open Child Protection plan, i.e. with no End Date"

--- a/cin_validator/rules/cin2022_23/rule_8940.py
+++ b/cin_validator/rules/cin2022_23/rule_8940.py
@@ -17,10 +17,11 @@ CPPendDate = ChildProtectionPlans.CPPendDate
 Header = CINTable.Header
 ReferenceDate = Header.ReferenceDate
 
+
 # define characteristics of rule
 @rule_definition(
     # write the rule code here
-    code=8940,
+    code="8940",
     # replace ChildProtectionPlans with the value in the module column of the excel sheet corresponding to this rule .
     # Note that even if multiple tables are involved, one table will be named in the module column.
     module=CINTable.ChildProtectionPlans,
@@ -272,7 +273,7 @@ def test_validate():
     # Check that the rule definition is what you wrote in the context above.
 
     # replace 2885 with the rule code and put the appropriate message in its place too.
-    assert result.definition.code == 8940
+    assert result.definition.code == "8940"
     assert (
         result.definition.message
         == "Child Protection Plan data contains overlapping dates"


### PR DESCRIPTION
The previous change made on this branch, to change the rule codes to strings at the point where they are read into the registry, caused the in-rule-file tests to fail.
This was because, the type conversion happened in the validation func so that by the time the test_validation function was being run, the rule code had changed already.
For example, for a rule defined with `code=100` (int) the @rule_definition decorator will read it in, convert, then store it as a string. such that by the time we get to the `test_validate` function,
assert `rule_code == 100` will fail. instead we'd have to do assert `rule_code= "100"`

Considerations:
- The goal is to have rule codes all as strings by the time they reach the frontend. It is fairly straightforward to convert the rule_code column to str just before sending it over. However, isn't intuitive to a new developer who enters the codebase.
- If we want rule codes as strings then they should only be entered as strings. Not strings sometimes and ints other times. Consistency is a good thing to lean toward. 

The changes in this pull request implement the second consideration and updates the type expectation in the definition of `rule_definition` such that it expects only str rule codes and will flag if otherwise.