### PR TITLE
configure vs code debug feature

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    // define a command to run the module write for me when I click into configurations.
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "cin_validator",
+            "args": ["run", "fake_data\\CIN_Census_2021.xml"],
+            "justMyCode": true
+
+
+        }
+    ]
+}


### PR DESCRIPTION
Customises launch.json so that the `python -m cin_validator path-to-file` command can be run from within the debugger. 
This will ease fault-finding and fixing in the future.